### PR TITLE
Support building static binaries via --enable-static-binary configure flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,11 @@ if test "$DOXYGEN_ENABLE" = "no"; then
 fi
 AM_CONDITIONAL([DOXYGEN_ENABLE], test x$DOXYGEN != xNO_DOXYGEN )
 
+AC_ARG_ENABLE(static-binary,
+    AS_HELP_STRING([--enable-static-binary],[enable static linking of binaries]),
+    STATIC_BINARY_ENABLE=$enableval, STATIC_BINARY_ENABLE=no)
+AM_CONDITIONAL([STATIC_BINARY_ENABLE], test "$STATIC_BINARY_ENABLE" = "yes")
+
 
 # Checks for libraries.
 

--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -150,7 +150,7 @@ static int init = 0;
 static char* timefmt = 0;
 static regex_t* regex = 0;
 
-int isdir( char const * path );
+static int isdir( char const * path );
 void record_stats( struct inotify_event const * event );
 int onestr_to_event(char const * event);
 
@@ -193,8 +193,8 @@ int onestr_to_event(char const * event);
  *
  * @param  mesg  A human-readable error message shown if assertion fails.
  */
-void _niceassert( long cond, int line, char const * file, char const * condstr,
-                  char const * mesg ) {
+static void _niceassert( long cond, int line, char const * file,
+                  char const * condstr, char const * mesg ) {
 	if ( cond ) return;
 
 	if ( mesg ) {
@@ -1594,7 +1594,7 @@ int inotifytools_error() {
 /**
  * @internal
  */
-int isdir( char const * path ) {
+static int isdir( char const * path ) {
 	static struct stat64 my_stat;
 
 	if ( -1 == lstat64( path, &my_stat ) ) {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,5 +5,9 @@ inotifywatch_SOURCES = inotifywatch.c common.c common.h
 AM_CFLAGS = -std=c99 -I../libinotifytools/src -L../libinotifytools/src
 LDADD = ../libinotifytools/src/libinotifytools.la
 
+if STATIC_BINARY_ENABLE
+AM_LDFLAGS = -static-libtool-libs
+endif
+
 dist-hook:
 	touch -d '2 days ago' $(distdir)/*


### PR DESCRIPTION
Needed a small change to the code to hide symbols duplicated between the library and the binaries.
