### PR TITLE
Add --include and --includei option

### DIFF
--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -149,6 +149,8 @@ static int error = 0;
 static int init = 0;
 static char* timefmt = 0;
 static regex_t* regex = 0;
+/* 0: --exclude[i], 1: --include[i] */
+static int invert_regexp = 0;
 
 int isdir( char const * path );
 void record_stats( struct inotify_event const * event );
@@ -1108,7 +1110,11 @@ struct inotify_event * inotifytools_next_events( int timeout, int num_events ) {
 	if (regex) {\
 		inotifytools_snprintf(match_name, MAX_STRLEN, A, "%w%f");\
 		if (0 == regexec(regex, match_name, 0, 0, 0)) {\
-			longjmp(jmp,0);\
+			if (!invert_regexp)\
+				longjmp(jmp,0);\
+		} else {\
+			if (invert_regexp)\
+				longjmp(jmp,0);\
 		}\
 	}\
 	if ( collect_stats ) {\
@@ -1992,14 +1998,16 @@ int inotifytools_get_max_user_watches() {
  * Ignore inotify events matching a particular regular expression.
  *
  * @a pattern is a regular expression and @a flags is a bitwise combination of
- * POSIX regular expression flags.
+ * POSIX regular expression flags. @a invert determines the type of filtering:
+ * 0 (--exclude[i]): exclude all files matching @a pattern
+ * 1 (--include[i]): exclude all files except those matching @a pattern
  *
  * On future calls to inotifytools_next_events() or inotifytools_next_event(),
  * the regular expression is executed on the filename of files on which
  * events occur.  If the regular expression matches, the matched event will be
  * ignored.
  */
-int inotifytools_ignore_events_by_regex( char const *pattern, int flags ) {
+static int do_ignore_events_by_regex( char const *pattern, int flags, int invert ) {
 	if (!pattern) {
 		if (regex) {
 			regfree(regex);
@@ -2012,6 +2020,7 @@ int inotifytools_ignore_events_by_regex( char const *pattern, int flags ) {
 	if (regex) { regfree(regex); }
 	else       { regex = (regex_t *)malloc(sizeof(regex_t)); }
 
+	invert_regexp = invert;
 	int ret = regcomp(regex, pattern, flags | REG_NOSUB);
 	if (0 == ret) return 1;
 
@@ -2020,6 +2029,36 @@ int inotifytools_ignore_events_by_regex( char const *pattern, int flags ) {
 	regex = 0;
 	error = EINVAL;
 	return 0;
+}
+
+/**
+ * Ignore inotify events matching a particular regular expression.
+ *
+ * @a pattern is a regular expression and @a flags is a bitwise combination of
+ * POSIX regular expression flags.
+ *
+ * On future calls to inotifytools_next_events() or inotifytools_next_event(),
+ * the regular expression is executed on the filename of files on which
+ * events occur.  If the regular expression matches, the matched event will be
+ * ignored.
+ */
+int inotifytools_ignore_events_by_regex( char const *pattern, int flags ) {
+	return do_ignore_events_by_regex(pattern, flags, 0);
+}
+
+/**
+ * Ignore inotify events NOT matching a particular regular expression.
+ *
+ * @a pattern is a regular expression and @a flags is a bitwise combination of
+ * POSIX regular expression flags.
+ *
+ * On future calls to inotifytools_next_events() or inotifytools_next_event(),
+ * the regular expression is executed on the filename of files on which
+ * events occur.  If the regular expression matches, the matched event will be
+ * ignored.
+ */
+int inotifytools_ignore_events_by_inverted_regex( char const *pattern, int flags ) {
+	return do_ignore_events_by_regex(pattern, flags, 1);
 }
 
 int event_compare(const void *p1, const void *p2, const void *config)

--- a/libinotifytools/src/inotifytools/inotifytools.h
+++ b/libinotifytools/src/inotifytools/inotifytools.h
@@ -29,6 +29,7 @@ int inotifytools_watch_recursively_with_exclude( char const * path,
                                                  char const ** exclude_list );
                                                  // [UH]
 int inotifytools_ignore_events_by_regex( char const *pattern, int flags );
+int inotifytools_ignore_events_by_inverted_regex( char const *pattern, int flags );
 struct inotify_event * inotifytools_next_event( int timeout );
 struct inotify_event * inotifytools_next_events( int timeout, int num_events );
 int inotifytools_error();

--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -47,8 +47,10 @@ bool parse_opts(
   char ** timefmt,
   char ** fromfile,
   char ** outfile,
-  char ** regex,
-  char ** iregex
+  char ** exc_regex,
+  char ** exc_iregex,
+  char ** inc_regex,
+  char ** inc_iregex
 );
 
 void print_help();
@@ -155,15 +157,18 @@ int main(int argc, char ** argv)
 	char * timefmt = NULL;
 	char * fromfile = NULL;
 	char * outfile = NULL;
-	char * regex = NULL;
-	char * iregex = NULL;
+	char * exc_regex = NULL;
+	char * exc_iregex = NULL;
+	char * inc_regex = NULL;
+	char * inc_iregex = NULL;
 	pid_t pid;
     int fd;
 
 	// Parse commandline options, aborting if something goes wrong
 	if ( !parse_opts(&argc, &argv, &events, &monitor, &quiet, &timeout,
 	                 &recursive, &csv, &daemon, &syslog, &format, &timefmt, 
-                         &fromfile, &outfile, &regex, &iregex) ) {
+                         &fromfile, &outfile,
+                         &exc_regex, &exc_iregex, &inc_regex, &inc_iregex) ) {
 		return EXIT_FAILURE;
 	}
 
@@ -180,11 +185,19 @@ int main(int argc, char ** argv)
 
 	if ( timefmt ) inotifytools_set_printf_timefmt( timefmt );
 	if (
-		(regex && !inotifytools_ignore_events_by_regex(regex, REG_EXTENDED) ) ||
-		(iregex && !inotifytools_ignore_events_by_regex(iregex, REG_EXTENDED|
+		(exc_regex && !inotifytools_ignore_events_by_regex(exc_regex, REG_EXTENDED) ) ||
+		(exc_iregex && !inotifytools_ignore_events_by_regex(exc_iregex, REG_EXTENDED|
 		                                                        REG_ICASE))
 	) {
 		fprintf(stderr, "Error in `exclude' regular expression.\n");
+		return EXIT_FAILURE;
+	}
+	if (
+		(inc_regex && !inotifytools_ignore_events_by_inverted_regex(inc_regex, REG_EXTENDED) ) ||
+		(inc_iregex && !inotifytools_ignore_events_by_inverted_regex(inc_iregex, REG_EXTENDED|
+		                                                        REG_ICASE))
+	) {
+		fprintf(stderr, "Error in `include' regular expression.\n");
 		return EXIT_FAILURE;
 	}
 
@@ -422,19 +435,22 @@ bool parse_opts(
   char ** timefmt,
   char ** fromfile,
   char ** outfile,
-  char ** regex,
-  char ** iregex
+  char ** exc_regex,
+  char ** exc_iregex,
+  char ** inc_regex,
+  char ** inc_iregex
 ) {
 	assert( argc ); assert( argv ); assert( events ); assert( monitor );
 	assert( quiet ); assert( timeout ); assert( csv ); assert( daemon );
 	assert( syslog ); assert( format ); assert( timefmt ); assert( fromfile ); 
-	assert( outfile ); assert( regex ); assert( iregex );
+	assert( outfile ); assert( exc_regex ); assert( exc_iregex );
+	assert( inc_regex ); assert( inc_iregex );
 
 	// Short options
 	char * opt_string = "mrhcdsqt:fo:e:";
 
 	// Construct array
-	struct option long_opts[17];
+	struct option long_opts[19];
 
 	// --help
 	long_opts[0].name = "help";
@@ -520,11 +536,21 @@ bool parse_opts(
 	long_opts[15].has_arg = 1;
 	long_opts[15].flag = NULL;
 	long_opts[15].val = (int)'b';
+	// --include
+	long_opts[16].name = "include";
+	long_opts[16].has_arg = 1;
+	long_opts[16].flag = NULL;
+	long_opts[16].val = (int)'j';
+	// --includei
+	long_opts[17].name = "includei";
+	long_opts[17].has_arg = 1;
+	long_opts[17].flag = NULL;
+	long_opts[17].val = (int)'k';
 	// Empty last element
-	long_opts[16].name = 0;
-	long_opts[16].has_arg = 0;
-	long_opts[16].flag = 0;
-	long_opts[16].val = 0;
+	long_opts[18].name = 0;
+	long_opts[18].has_arg = 0;
+	long_opts[18].flag = 0;
+	long_opts[18].val = 0;
 
 	// Get first option
 	char curr_opt = getopt_long(*argc, *argv, opt_string, long_opts, NULL);
@@ -596,12 +622,22 @@ bool parse_opts(
 
 			// --exclude
 			case 'a':
-				(*regex) = optarg;
+				(*exc_regex) = optarg;
 				break;
 
 			// --excludei
 			case 'b':
-				(*iregex) = optarg;
+				(*exc_iregex) = optarg;
+				break;
+
+			// --include
+			case 'j':
+				(*inc_regex) = optarg;
+				break;
+
+			// --includei
+			case 'k':
+				(*inc_iregex) = optarg;
 				break;
 
 			// --fromfile
@@ -666,8 +702,19 @@ bool parse_opts(
 		return false;
 	}
 
-	if ( *regex && *iregex ) {
+	if ( *exc_regex && *exc_iregex ) {
 		fprintf(stderr, "--exclude and --excludei cannot both be specified.\n");
+		return false;
+	}
+
+	if ( *inc_regex && *inc_iregex ) {
+		fprintf(stderr, "--include and --includei cannot both be specified.\n");
+		return false;
+	}
+
+	if ( *inc_regex && *exc_regex || *inc_regex && *exc_iregex ||
+			*inc_iregex && *exc_regex || *inc_iregex && *exc_iregex) {
+		fprintf(stderr, "include and exclude regexp cannot both be specified.\n");
 		return false;
 	}
 
@@ -715,6 +762,12 @@ void print_help()
 	       "\t              \textended regular expression <pattern>.\n");
 	printf("\t--excludei <pattern>\n"
 	       "\t              \tLike --exclude but case insensitive.\n");
+	printf("\t--include <pattern>\n"
+	       "\t              \tExclude all events on files except the ones\n"
+	       "\t              \tmatching the extended regular expression\n"
+	       "\t              \t<pattern>.\n");
+	printf("\t--includei <pattern>\n"
+	       "\t              \tLike --include but case insensitive.\n");
 	printf("\t-m|--monitor  \tKeep listening for events forever.  Without\n"
 	       "\t              \tthis option, inotifywait will exit after one\n"
 	       "\t              \tevent is received.\n");


### PR DESCRIPTION
(also posted on the mailing list)

Add --include and --includei option

Useful for e.g.:

while inotifywait -e modify -e close_write -e move_self \
    --include '.*.(bib|svg|tex)$' -r . ; do make ; done

Can't be easily emulated using --exclude, because it is not easy nor
pleasing to negate POSIX regular expressions.

Maybe it would be cleaner to control regular expressions via options,
e.g.:

```
--filter <pattern>
```

-i, --ignore-case
-v, --invert-filter

But that would break compatibility with older versions. Adding two new
options seems more inotify-tools style (like --excudei).

Same with library: Added inotifytools_ignore_events_by_inverted_regex()
(instead of extending old function) for backwards-compatibility.
