### PR TITLE
Allow combining monitor and timeout option

### DIFF
--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -707,11 +707,6 @@ bool parse_opts(
 
 	}
 
-	if ( *monitor && *timeout != 0 ) {
-		fprintf(stderr, "-m and -t cannot both be specified.\n");
-		return false;
-	}
-
 	if ( *exc_regex && *exc_iregex ) {
 		fprintf(stderr, "--exclude and --excludei cannot both be specified.\n");
 		return false;


### PR DESCRIPTION
inotifywait would disallow combining -m and -t option, but removing that
check actually enables a feature where we monitor for a maximum amount
of time (after last event)

fixes issue #16
