### PR TITLE
Trailing slashes for directory watches

### DIFF
--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -264,9 +264,15 @@ watch *watch_from_wd( int wd ) {
  * @internal
  */
 watch *watch_from_filename( char const *filename ) {
-	watch w;
+	watch w, *ret;
 	w.filename = (char*)filename;
-	return (watch*)rbfind(&w, tree_filename);
+	ret = (watch*)rbfind(&w, tree_filename);
+	if (!ret && filename[strlen(filename)-1] != '/') {
+		nasprintf(&w.filename, "%s/", filename);
+		ret = (watch*)rbfind(&w, tree_filename);
+		free(w.filename);
+	}
+	return ret;
 }
 
 /**


### PR DESCRIPTION
inotifytools_watch_files() will append a / to any filename that is
is a directory before invoking create_watch()

update watch_from_filename() to search for filenames with a trailing /
if filename itself isn't found in tree_filename first
