### PR TITLE
Added -P/--no-dereference to watch a symlink

### DIFF
--- a/man/inotifywait.1.in
+++ b/man/inotifywait.1.in
@@ -5,7 +5,7 @@ inotifywait \- wait for changes to files using inotify
 
 .SH SYNOPSIS
 .B inotifywait
-.RB [ \-hcmrq ]
+.RB [ \-hcmrPq ]
 .RB [ \-e
 <event> ]
 .RB [ \-t
@@ -89,6 +89,9 @@ Output events to <file> rather than stdout.
 Output errors to
 .BR syslog(3)
 system log module rather than stderr.
+.TP
+.B \-P, \-\-no\-dereference
+Do not follow symlinks.
 .TP
 .B \-r, \-\-recursive
 Watch all subdirectories of any directories passed as arguments.  Watches

--- a/man/inotifywatch.1.in
+++ b/man/inotifywatch.1.in
@@ -5,7 +5,7 @@ inotifywatch \- gather filesystem access statistics using inotify
 
 .SH SYNOPSIS
 .B inotifywatch
-.RB [ \-hvzrqf ]
+.RB [ \-hvzrPqf ]
 .RB [ \-e
 <event> ]
 .RB [ \-t
@@ -95,6 +95,10 @@ inotify watch will be established per subdirectory, it is possible that the
 maximum amount of inotify watches per user will be reached.  The default
 maximum is 8192; it can be increased by writing to
 .BR /proc/sys/fs/inotify/max_user_watches .
+
+.TP
+.B \-P, \-\-no\-dereference
+Do not follow symlinks.
 
 .TP
 .B \-t <seconds>, \-\-timeout <seconds>

--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -34,9 +34,10 @@ extern int optind, opterr, optopt;
 // METHODS
 bool parse_opts(int *argc, char ***argv, int *events, bool *monitor, int *quiet,
                 long int *timeout, int *recursive, bool *csv, bool *daemon,
-                bool *syslog, char **format, char **timefmt, char **fromfile,
-                char **outfile, char **exc_regex, char **exc_iregex,
-                char **inc_regex, char **inc_iregex);
+                bool *syslog, bool *no_dereference, char **format,
+                char **timefmt, char **fromfile, char **outfile,
+                char **exc_regex, char **exc_iregex, char **inc_regex,
+                char **inc_iregex);
 
 void print_help();
 
@@ -136,6 +137,7 @@ int main(int argc, char **argv) {
     bool csv = false;
     bool dodaemon = false;
     bool syslog = false;
+    bool no_dereference = false;
     char *format = NULL;
     char *timefmt = NULL;
     char *fromfile = NULL;
@@ -148,9 +150,9 @@ int main(int argc, char **argv) {
 
     // Parse commandline options, aborting if something goes wrong
     if (!parse_opts(&argc, &argv, &events, &monitor, &quiet, &timeout,
-                    &recursive, &csv, &dodaemon, &syslog, &format, &timefmt,
-                    &fromfile, &outfile, &exc_regex, &exc_iregex, &inc_regex,
-                    &inc_iregex)) {
+                    &recursive, &csv, &dodaemon, &syslog, &no_dereference,
+                    &format, &timefmt, &fromfile, &outfile, &exc_regex,
+                    &exc_iregex, &inc_regex, &inc_iregex)) {
         return EXIT_FAILURE;
     }
 
@@ -189,6 +191,9 @@ int main(int argc, char **argv) {
     orig_events = events;
     if (monitor && recursive) {
         events = events | IN_CREATE | IN_MOVED_TO | IN_MOVED_FROM;
+    }
+    if (no_dereference) {
+        events = events | IN_DONT_FOLLOW;
     }
 
     FileList list = construct_path_list(argc, argv, fromfile);
@@ -412,9 +417,10 @@ int main(int argc, char **argv) {
 
 bool parse_opts(int *argc, char ***argv, int *events, bool *monitor, int *quiet,
                 long int *timeout, int *recursive, bool *csv, bool *daemon,
-                bool *syslog, char **format, char **timefmt, char **fromfile,
-                char **outfile, char **exc_regex, char **exc_iregex,
-                char **inc_regex, char **inc_iregex) {
+                bool *syslog, bool *no_dereference, char **format,
+                char **timefmt, char **fromfile, char **outfile,
+                char **exc_regex, char **exc_iregex, char **inc_regex,
+                char **inc_iregex) {
     assert(argc);
     assert(argv);
     assert(events);
@@ -424,6 +430,7 @@ bool parse_opts(int *argc, char ***argv, int *events, bool *monitor, int *quiet,
     assert(csv);
     assert(daemon);
     assert(syslog);
+    assert(no_dereference);
     assert(format);
     assert(timefmt);
     assert(fromfile);
@@ -449,7 +456,7 @@ bool parse_opts(int *argc, char ***argv, int *events, bool *monitor, int *quiet,
     static char *newlineformat;
 
     // Short options
-    static const char opt_string[] = "mrhcdsqt:fo:e:";
+    static const char opt_string[] = "mrhcdsPqt:fo:e:";
 
     // Long options
     static const struct option long_opts[] = {
@@ -463,6 +470,7 @@ bool parse_opts(int *argc, char ***argv, int *events, bool *monitor, int *quiet,
         {"csv", no_argument, NULL, 'c'},
         {"daemon", no_argument, NULL, 'd'},
         {"syslog", no_argument, NULL, 's'},
+        {"no-dereference", no_argument, NULL, 'P'},
         {"format", required_argument, NULL, 'n'},
         {"timefmt", required_argument, NULL, 'i'},
         {"fromfile", required_argument, NULL, 'z'},
@@ -517,6 +525,11 @@ bool parse_opts(int *argc, char ***argv, int *events, bool *monitor, int *quiet,
         // --syslog or -s
         case 's':
             (*syslog) = true;
+            break;
+
+        // --no-dereference or -P
+        case 'P':
+            (*no_dereference) = true;
             break;
 
         // --filename or -f

--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -706,6 +706,8 @@ void print_help() {
         "\t-d|--daemon   \tSame as --monitor, except run in the background\n"
         "\t              \tlogging events to a file specified by --outfile.\n"
         "\t              \tImplies --syslog.\n");
+    printf("\t-P|--no-dereference\n"
+           "\t              \tDo not follow symlinks.\n");
     printf("\t-r|--recursive\tWatch directories recursively.\n");
     printf("\t--fromfile <file>\n"
            "\t              \tRead files to watch from <file> or `-' for "

--- a/src/inotifywatch.c
+++ b/src/inotifywatch.c
@@ -30,8 +30,8 @@ extern int optind, opterr, optopt;
 // METHODS
 bool parse_opts(int *argc, char ***argv, int *events, long int *timeout,
                 int *verbose, int *zero, int *sort, int *recursive,
-                char **fromfile, char **exc_regex, char **exc_iregex,
-                char **inc_regex, char **inc_iregex);
+                int *no_dereference, char **fromfile, char **exc_regex,
+                char **exc_iregex, char **inc_regex, char **inc_iregex);
 
 void print_help();
 
@@ -73,6 +73,7 @@ int main(int argc, char **argv) {
     int verbose = 0;
     zero = 0;
     int recursive = 0;
+    int no_dereference = 0;
     char *fromfile = 0;
     sort = -1;
     done = false;
@@ -85,8 +86,8 @@ int main(int argc, char **argv) {
 
     // Parse commandline options, aborting if something goes wrong
     if (!parse_opts(&argc, &argv, &events, &timeout, &verbose, &zero, &sort,
-                    &recursive, &fromfile, &exc_regex, &exc_iregex, &inc_regex,
-                    &inc_iregex)) {
+                    &recursive, &no_dereference, &fromfile, &exc_regex,
+                    &exc_iregex, &inc_regex, &inc_iregex)) {
         return EXIT_FAILURE;
     }
 
@@ -118,6 +119,8 @@ int main(int argc, char **argv) {
     // If events is still 0, make it all events.
     if (!events)
         events = IN_ALL_EVENTS;
+    if (no_dereference)
+        events = events | IN_DONT_FOLLOW;
 
     FileList list = construct_path_list(argc, argv, fromfile);
 
@@ -363,8 +366,8 @@ int print_info() {
 
 bool parse_opts(int *argc, char ***argv, int *e, long int *timeout,
                 int *verbose, int *z, int *s, int *recursive,
-                char **fromfile, char **exc_regex, char **exc_iregex,
-                char **inc_regex, char **inc_iregex) {
+                int *no_dereference, char **fromfile, char **exc_regex,
+                char **exc_iregex, char **inc_regex, char **inc_iregex) {
     assert(argc);
     assert(argv);
     assert(e);
@@ -373,6 +376,7 @@ bool parse_opts(int *argc, char ***argv, int *e, long int *timeout,
     assert(z);
     assert(s);
     assert(recursive);
+    assert(no_dereference);
     assert(fromfile);
     assert(exc_regex);
     assert(exc_iregex);
@@ -384,7 +388,7 @@ bool parse_opts(int *argc, char ***argv, int *e, long int *timeout,
     bool sort_set = false;
 
     // Short options
-    static const char opt_string[] = "hra:d:zve:t:";
+    static const char opt_string[] = "hrPa:d:zve:t:";
 
     // Construct array
     static const struct option long_opts[] = {
@@ -396,6 +400,7 @@ bool parse_opts(int *argc, char ***argv, int *e, long int *timeout,
         {"ascending", required_argument, NULL, 'a'},
         {"descending", required_argument, NULL, 'd'},
         {"recursive", no_argument, NULL, 'r'},
+        {"no-dereference", no_argument, NULL, 'P'},
         {"fromfile", required_argument, NULL, 'o'},
         {"exclude", required_argument, NULL, 'c'},
         {"excludei", required_argument, NULL, 'b'},
@@ -425,6 +430,9 @@ bool parse_opts(int *argc, char ***argv, int *e, long int *timeout,
         // --recursive or -r
         case 'r':
             ++(*recursive);
+            break;
+        case 'P':
+            ++(*no_dereference);
             break;
 
         // --zero or -z

--- a/src/inotifywatch.c
+++ b/src/inotifywatch.c
@@ -610,6 +610,8 @@ void print_help() {
            "\t\tif they consist only of zeros (the default is to not output\n"
            "\t\tthese rows and columns).\n");
     printf("\t-r|--recursive\tWatch directories recursively.\n");
+    printf("\t-P|--no-dereference\n"
+           "\t\tDo not follow symlinks.\n");
     printf("\t-t|--timeout <seconds>\n"
            "\t\tListen only for specified amount of time in seconds; if\n"
            "\t\tomitted or negative, inotifywatch will execute until receiving "

--- a/t/inotifywait-no-dereference-ignore-symlinked-file.t
+++ b/t/inotifywait-no-dereference-ignore-symlinked-file.t
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+test_description='--no-dereference causes inotifywait to ignore events on symlink target'
+
+. ./sharness.sh
+
+run_() {
+    export LD_LIBRARY_PATH="../../libinotifytools/src/.libs/"
+    touch test &&
+	ln -s test test-symlink &&
+	{(sleep 1 && touch test)&} &&
+    ../../src/.libs/inotifywait --quiet --no-dereference --timeout 2 test-symlink
+}
+
+test_expect_success 'Exit code 2 is returned' '
+    test_expect_code 2 run_
+'
+
+test_done

--- a/t/inotifywait-no-dereference-respond-to-symlink-event.t
+++ b/t/inotifywait-no-dereference-respond-to-symlink-event.t
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+test_description='--no-dereference causes inotifywait to respond to events on symlink'
+
+. ./sharness.sh
+
+run_() {
+    export LD_LIBRARY_PATH="../../libinotifytools/src/.libs/"
+    touch test &&
+	ln -s test test-symlink &&
+	{(sleep 1 && touch -h test-symlink)&} &&
+    ../../src/.libs/inotifywait --quiet --no-dereference --timeout 2 test-symlink
+}
+
+test_expect_success 'Exit code 0 is returned' '
+    run_
+'
+
+test_done


### PR DESCRIPTION
```
Allows watching symlinks by ORing IN_DONT_FOLLOW into the set of events
This should silently no-op on kernels prior to 2.6.15
```
