### PR TITLE
Makefile.am: add build rule for README

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,8 @@ ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = libinotifytools src man
 
+README: README.md
+
 dist-hook:
 # Automake official documentation states that dist-hook should assume files
 # are not writable.

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-cp README.md README
 autoreconf --install "$@" || exit 1


### PR DESCRIPTION
Fixes:

| configure.ac:17: installing 'config/config.sub'
| configure.ac:16: installing 'config/install-sh'
| configure.ac:16: installing 'config/missing'
| Makefile.am: error: required file './README' not found
| libinotifytools/src/Makefile.am: installing 'config/depcomp'

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>