### PR TITLE
Allow produce NULL-delimited output

### DIFF
--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -1669,6 +1669,8 @@ int inotifytools_get_num_watches() {
  *               string previously passed to inotifytools_set_printf_timefmt(),
  *               or replaced with an empty string if that function has never
  *               been called.
+ *  \li \c \%0 - Replaced with the 'NUL' character
+ *  \li \c \%n - Replaced with the 'Line Feed' character
  *
  * @section example Example
  * @code
@@ -1716,6 +1718,8 @@ int inotifytools_printf( struct inotify_event* event, char* fmt ) {
  *               string previously passed to inotifytools_set_printf_timefmt(),
  *               or replaced with an empty string if that function has never
  *               been called.
+ *  \li \c \%0 - Replaced with the 'NUL' character
+ *  \li \c \%n - Replaced with the 'Line Feed' character
  *
  * @section example Example
  * @code
@@ -1772,6 +1776,8 @@ int inotifytools_fprintf( FILE* file, struct inotify_event* event, char* fmt ) {
  *               string previously passed to inotifytools_set_printf_timefmt(),
  *               or replaced with an empty string if that function has never
  *               been called.
+ *  \li \c \%0 - Replaced with the 'NUL' character
+ *  \li \c \%n - Replaced with the 'Line Feed' character
  *
  * @section example Example
  * @code
@@ -1824,6 +1830,8 @@ int inotifytools_sprintf( struct nstring * out, struct inotify_event* event, cha
  *               string previously passed to inotifytools_set_printf_timefmt(),
  *               or replaced with an empty string if that function has never
  *               been called.
+ *  \li \c \%0 - Replaced with the 'NUL' character
+ *  \li \c \%n - Replaced with the 'Line Feed' character
  *
  * @section example Example
  * @code
@@ -1887,6 +1895,18 @@ int inotifytools_snprintf( struct nstring * out, int size,
 
 		if ( ch1 == '%' ) {
 			out->buf[ind++] = '%';
+			++i;
+			continue;
+		}
+
+		if ( ch1 == '0' ) {
+			out->buf[ind++] = '\0';
+			++i;
+			continue;
+		}
+
+		if ( ch1 == 'n' ) {
+			out->buf[ind++] = '\n';
 			++i;
 			continue;
 		}

--- a/libinotifytools/src/inotifytools/inotifytools.h
+++ b/libinotifytools/src/inotifytools/inotifytools.h
@@ -13,6 +13,20 @@ extern "C"
 
 #include <stdio.h>
 
+#define MAX_STRLEN 4096
+
+/** @struct nstring
+ *  @brief This structure holds string that can contain any charater including NULL.
+ *  @var nstring::buf
+ *  Member 'buf' contains character buffer.  It can hold up to 4096 characters.
+ *  @var nstring::len
+ *  Member 'len' contains number of characters in buffer.
+ */
+struct nstring {
+	char buf[MAX_STRLEN];
+	unsigned int len;
+};
+
 int inotifytools_str_to_event(char const * event);
 int inotifytools_str_to_event_sep(char const * event, char sep);
 char * inotifytools_event_to_str(int events);
@@ -49,8 +63,8 @@ int inotifytools_get_num_watches();
 
 int inotifytools_printf( struct inotify_event* event, char* fmt );
 int inotifytools_fprintf( FILE* file, struct inotify_event* event, char* fmt );
-int inotifytools_sprintf( char * out, struct inotify_event* event, char* fmt );
-int inotifytools_snprintf( char * out, int size, struct inotify_event* event,
+int inotifytools_sprintf( struct nstring * out, struct inotify_event* event, char* fmt );
+int inotifytools_snprintf( struct nstring * out, int size, struct inotify_event* event,
                            char* fmt );
 void inotifytools_set_printf_timefmt( char * fmt );
 

--- a/man/inotifywait.1.in
+++ b/man/inotifywait.1.in
@@ -150,6 +150,10 @@ Set a time format string as accepted by strftime(3) for use with the `%T' conver
 in the \-\-format option.
 
 .TP
+.B \-\-no-newline
+Don't print newline symbol after user-specified format in the \-\-format option.
+
+.TP
 .B \-\-format <fmt>
 Output in a user-specified format, using printf-like syntax.  The event strings
 output are limited to around 4000 characters and will be truncated to this length.
@@ -341,6 +345,17 @@ OPEN goodfile
 ATTRIB goodfile
 CLOSE_WRITE:CLOSE goodfile
 DELETE badfile
+.fi
+
+.SS Example 4
+Enforce file permissions in directory `~/test'
+
+.nf
+inotifywait -qmr -e 'moved_to,create' --format '%w%f%0' --no-newline ~/test |\\
+    while IFS= read -r -d '' file
+    do
+	  chmod -v a+rX "$file"
+    done
 .fi
 
 

--- a/man/inotifywait.1.in
+++ b/man/inotifywait.1.in
@@ -179,6 +179,14 @@ in the place of `X'.
 Replaced with the current Time in the format specified by the \-\-timefmt option,
 which should be a format string suitable for passing to strftime(3).
 
+.TP
+%0
+Replaced with NUL.
+
+.TP
+%n
+Replaced with Line Feed.
+
 
 
 .SH "EXIT STATUS"

--- a/t/inotifywait-format-option-null.t
+++ b/t/inotifywait-format-option-null.t
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+test_description='Check producing NUL-delimited output'
+
+. ./sharness.sh
+
+logfile="log"
+
+run_() {
+  touch $logfile
+
+  export LD_LIBRARY_PATH="../../libinotifytools/src/.libs/"
+
+  ../../src/.libs/inotifywait \
+    --monitor \
+    --quiet \
+    --outfile $logfile \
+    --format '%w%f%0' \
+    --no-newline \
+    --event create \
+    --event moved_to \
+    --event moved_from \
+    $(realpath ./) &
+
+  PID="$!"
+  sleep 1
+
+  touch test-file-src
+
+  mv test-file-src test-file-dst
+
+  sleep 1
+
+  kill ${PID}
+}
+
+test_expect_success 'the output is delimited by NUL' \
+	'
+	set -e
+	trap "set +e" RETURN
+	run_
+	srcfile="${PWD}/test-file-src"
+	dstfile="${PWD}/test-file-dst"
+
+	return $(printf "${srcfile}\0${srcfile}\0${dstfile}\0" | cmp -s "${logfile}")
+	'
+
+test_done


### PR DESCRIPTION
inotifywait can now handle NULL in output formatted with `--format` (%0). Now it's possible to handle filenames containing any character including newline. `inotifywait` won't add newline at end of format string if option `--no-newline` is used.
Functions `inotifytools_snprintf` and `inotifytools_sprintf` store results in `struct nstring`, not char array.

Following issues are fixed:
    Fix #20

I've fixed up this (inotify-tools/inotify-tools#88) pull request.
Thanks for @813gan
