### PR TITLE
Support --ready for clients to avoid races

### DIFF
--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -330,7 +330,6 @@ int main(int argc, char **argv) {
 
     if (ready_event) {
         printf("READY\n");
-	fflush(stdout);
     }
 
     // Now wait till we get event
@@ -338,6 +337,9 @@ int main(int argc, char **argv) {
     char *moved_from = 0;
 
     do {
+
+        fflush(NULL);
+
         event = inotifytools_next_event(timeout);
         if (!event) {
             if (!inotifytools_error()) {
@@ -409,8 +411,6 @@ int main(int argc, char **argv) {
                 } // moved_from
             }
         }
-
-        fflush(NULL);
 
     } while (monitor);
 

--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -330,6 +330,7 @@ int main(int argc, char **argv) {
 
     if (ready_event) {
         printf("READY\n");
+	fflush(stdout);
     }
 
     // Now wait till we get event

--- a/t/inotifywait-format-option-cookie-ready.t
+++ b/t/inotifywait-format-option-cookie-ready.t
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+test_description='Resolves Issue #72
+
+Make transaction id (cookie) available as part of the format string using %c'
+
+. ./sharness.sh
+
+logfile="log"
+
+run_() {
+  # Setup code, defer an ATTRIB event for after
+  # inotifywait has been set up.
+  touch $logfile
+
+  export LD_LIBRARY_PATH="../../libinotifytools/src/.libs/"
+
+  ../../src/.libs/inotifywait \
+    --monitor \
+    --daemon \
+    --quiet \
+    --outfile $logfile \
+    --format '%c %e %w%f' \
+    --event create \
+    --event moved_to \
+    --event moved_from \
+    --ready \
+    $(realpath ./)
+
+  PID="$!"
+
+  touch test-file-src
+
+  mv test-file-src test-file-dst
+
+  kill ${PID}
+}
+
+test_expect_success \
+	'event logged' \
+	'
+	set -e
+	trap "set +e" RETURN
+	run_
+	local READY="$(cat "${logfile}" | sed -n 1p)"
+	[[ "${READY}" == "READY" ]] || return 1
+	local NONCOOKIE="$(cat "${logfile}" | sed -n 2p | grep -Eo "^[^ ]+")"
+	#Make sure cookie is 0 for single events
+    	[[ "${NONCOOKIE}" == "0" ]] || return 1
+	local COOKIE_A="$(cat "${logfile}" | sed -n 3p | grep -Eo "^[^ ]+")"
+    	[[ -n "${COOKIE_A}" ]] || return 1
+	local COOKIE_B="$(cat "${logfile}" | sed -n 4p | grep -Eo "^[^ ]+")"
+    	[[ "${COOKIE_A}" == "${COOKIE_B}" ]] || return 1
+    	return 0
+	'
+
+test_done


### PR DESCRIPTION
https://github.com/inotify-tools/inotify-tools/issues/126

When --ready is used, emit READY as a pseudo-event to allow
clients to synchronise.