### PR TITLE
Fix omission of --include/--includei options in man pages

### DIFF
--- a/man/inotifywait.1.in
+++ b/man/inotifywait.1.in
@@ -117,23 +117,23 @@ of fatal errors.
 
 .TP
 .B \-\-exclude <pattern>
-Do not process any events whose filename matches the specified POSIX extended
-regular expression, case sensitive.
+Do not process any events for the subset of files whose filenames match the
+specified POSIX regular expression, case sensitive.
 
 .TP
 .B \-\-excludei <pattern>
-Do not process any events whose filename matches the specified POSIX extended
-regular expression, case insensitive.
+Do not process any events for the subset of files whose filenames match the
+specified POSIX regular expression, case insensitive.
 
 .TP
 .B \-\-include <pattern>
-Require that filenames also match the case sensitive POSIX extended regular
-expression in order for events to be included.
+Process events only for the subset of files whose filenames match the specified
+POSIX regular expression, case sensitive.
 
 .TP
 .B \-\-includei <pattern>
-Require that filenames also match the case insensitive POSIX extended regular
-expression in order for events to be included.
+Process events only for the subset of files whose filenames match the specified
+POSIX regular expression, case insensitive.
 
 .TP
 .B \-t <seconds>, \-\-timeout <seconds>

--- a/man/inotifywait.1.in
+++ b/man/inotifywait.1.in
@@ -126,6 +126,16 @@ Do not process any events whose filename matches the specified POSIX extended
 regular expression, case insensitive.
 
 .TP
+.B \-\-include <pattern>
+Require that filenames also match the case sensitive POSIX extended regular
+expression in order for events to be included.
+
+.TP
+.B \-\-includei <pattern>
+Require that filenames also match the case insensitive POSIX extended regular
+expression in order for events to be included.
+
+.TP
 .B \-t <seconds>, \-\-timeout <seconds>
 Exit if an appropriate event has not occurred within <seconds> seconds. If
 <seconds> is a negative value (the default), wait indefinitely for an event.

--- a/man/inotifywatch.1.in
+++ b/man/inotifywatch.1.in
@@ -72,23 +72,23 @@ of output!
 
 .TP
 .B \-\-exclude <pattern>
-Do not process any events whose filename matches the specified POSIX extended
-regular expression, case sensitive.
+Do not process any events for the subset of files whose filenames match the
+specified POSIX regular expression, case sensitive.
 
 .TP
 .B \-\-excludei <pattern>
-Do not process any events whose filename matches the specified POSIX extended
-regular expression, case insensitive.
+Do not process any events for the subset of files whose filenames match the
+specified POSIX regular expression, case insensitive.
 
 .TP
 .B \-\-include <pattern>
-Require that filenames also match the case sensitive POSIX extended regular
-expression in order for events to be included.
+Process events only for the subset of files whose filenames match the specified
+POSIX regular expression, case sensitive.
 
 .TP
 .B \-\-includei <pattern>
-Require that filenames also match the case insensitive POSIX extended regular
-expression in order for events to be included.
+Process events only for the subset of files whose filenames match the specified
+POSIX regular expression, case insensitive.
 
 .TP
 .B \-r, \-\-recursive

--- a/man/inotifywatch.1.in
+++ b/man/inotifywatch.1.in
@@ -81,6 +81,16 @@ Do not process any events whose filename matches the specified POSIX extended
 regular expression, case insensitive.
 
 .TP
+.B \-\-include <pattern>
+Require that filenames also match the case sensitive POSIX extended regular
+expression in order for events to be included.
+
+.TP
+.B \-\-includei <pattern>
+Require that filenames also match the case insensitive POSIX extended regular
+expression in order for events to be included.
+
+.TP
 .B \-r, \-\-recursive
 Watch all subdirectories of any directories passed as arguments.  Watches
 will be set up recursively to an unlimited depth.  Symbolic links are not


### PR DESCRIPTION
Hi - Thanks for working on this project, it has really helped me out in some tasks that I automate. In the course of writing some scripts, I noticed the --include/--includei options and accompanying descriptions were missing from the man pages for both inotifywait and inotifywatch. Hopefully including these will help someone else out there when they are using the tools for the first time.