### PR TITLE
Fanotify support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,4 @@
 BasedOnStyle: chromium
+IndentWidth: 8
+UseTab: Always
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ config/
 
 /libinotifytools/src/doc
 /libinotifytools/src/inotifytools/inotify.h
+/libinotifytools/src/inotifytools/fanotify.h
 /libinotifytools/src/inotifytools/stamp-h2
 
 /src/inotifywait

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ config/
 
 /src/inotifywait
 /src/inotifywatch
+/src/fsnotifywait
+/src/fsnotifywatch
 
 config.h
 config.h.in

--- a/configure.ac
+++ b/configure.ac
@@ -58,14 +58,21 @@ AC_COMPILE_IFELSE(
   [AC_MSG_RESULT([nope, using own inotify headers])]
 )
 
+# Checks for fanotify support.
 AC_MSG_CHECKING([whether sys/fanotify.h actually works])
 AC_COMPILE_IFELSE(
   [AC_LANG_PROGRAM([[#include <sys/fanotify.h>]],
                   [[return (-1 == fanotify_init(FAN_REPORT_DFID_NAME, 0));]]
   )],
-  [AC_MSG_RESULT([yup]); AC_DEFINE([SYS_FANOTIFY_H_EXISTS_AND_WORKS],[1],[sys/fanotify.h exists and works correctly])],
-  [AC_MSG_RESULT([nope, using own fanotify headers])]
+  [AC_MSG_RESULT([yup]); DEFAULT_FANOTIFY=yes; AC_DEFINE([SYS_FANOTIFY_H_EXISTS_AND_WORKS],[1],[sys/fanotify.h exists and works correctly])],
+  [AC_MSG_RESULT([nope, using own fanotify headers]); DEFAULT_FANOTIFY=no]
 )
+
+AC_ARG_ENABLE(fanotify,
+    AS_HELP_STRING([--enable-fanotify],[enable fanotify support]),
+    ENABLE_FANOTIFY=$enableval, DOXYGEN_ENABLE="$DEFAULT_FANOTIFY"
+)
+AM_CONDITIONAL([ENABLE_FANOTIFY], test "$ENABLE_FANOTIFY" = "yes")
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,8 @@ AC_CONFIG_FILES([
   man/Makefile
   man/inotifywait.1
   man/inotifywatch.1
+  man/fsnotifywait.1
+  man/fsnotifywatch.1
   libinotifytools/Makefile
   libinotifytools/src/Makefile
   libinotifytools/src/inotifytools/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_SRCDIR([src/inotifywait.c])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_HEADERS([libinotifytools/src/inotifytools/inotify.h])
+AC_CONFIG_HEADERS([libinotifytools/src/inotifytools/fanotify.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_DEFINE([_GNU_SOURCE], [], [For a few GNU-specific functions])
 AC_PROG_MAKE_SET
@@ -46,7 +47,7 @@ AM_CONDITIONAL([STATIC_BINARY_ENABLE], test "$STATIC_BINARY_ENABLE" = "yes")
 # Checks for libraries.
 
 # Checks for header files.
-AC_CHECK_HEADERS([sys/inotify.h mcheck.h])
+AC_CHECK_HEADERS([sys/inotify.h sys/fanotify.h mcheck.h])
 AC_LANG(C)
 AC_MSG_CHECKING([whether sys/inotify.h actually works])
 AC_COMPILE_IFELSE(
@@ -55,6 +56,15 @@ AC_COMPILE_IFELSE(
   )],
   [AC_MSG_RESULT([yup]); AC_DEFINE([SYS_INOTIFY_H_EXISTS_AND_WORKS],[1],[sys/inotify.h exists and works correctly])],
   [AC_MSG_RESULT([nope, using own inotify headers])]
+)
+
+AC_MSG_CHECKING([whether sys/fanotify.h actually works])
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM([[#include <sys/fanotify.h>]],
+                  [[return (-1 == fanotify_init(FAN_REPORT_DFID_NAME, 0));]]
+  )],
+  [AC_MSG_RESULT([yup]); AC_DEFINE([SYS_FANOTIFY_H_EXISTS_AND_WORKS],[1],[sys/fanotify.h exists and works correctly])],
+  [AC_MSG_RESULT([nope, using own fanotify headers])]
 )
 
 # Checks for typedefs, structures, and compiler characteristics.

--- a/libinotifytools/src/Makefile.am
+++ b/libinotifytools/src/Makefile.am
@@ -13,6 +13,7 @@ TESTS = test
 EXTRA_DIST = example.c Doxyfile
 
 nobase_include_HEADERS = inotifytools/inotifytools.h inotifytools/inotify-nosys.h inotifytools/inotify.h
+nobase_include_HEADERS += inotifytools/fanotify-dfid-name.h inotifytools/fanotify.h
 
 AM_CFLAGS = -std=c99 -Wall -Wshadow -Werror
 

--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -35,6 +35,22 @@
 
 #include "inotifytools/inotify.h"
 
+#ifdef __FreeBSD__
+struct fanotify_event_fid;
+#else
+// Linux only
+#define LINUX_FANOTIFY
+
+#include <fcntl.h>
+#include <sys/vfs.h>
+#include "inotifytools/fanotify.h"
+
+struct fanotify_event_fid {
+	__kernel_fsid_t fsid;
+	struct file_handle handle;
+};
+#endif
+
 /**
  * @file inotifytools/inotifytools.h
  * @brief inotifytools library public interface.
@@ -132,6 +148,7 @@ static int inotify_fd;
 int collect_stats = 0;
 
 struct rbtree *tree_wd = 0;
+struct rbtree *tree_fid = 0;
 struct rbtree *tree_filename = 0;
 static int error = 0;
 int init = 0;
@@ -218,6 +235,21 @@ int wd_compare(const void *d1, const void *d2, const void *config) {
 	return ((watch*)d1)->wd - ((watch*)d2)->wd;
 }
 
+int fid_compare(const void *d1, const void *d2, const void *config) {
+#ifdef LINUX_FANOTIFY
+	if (!d1 || !d2) return d1 - d2;
+	watch *w1 = (watch *)d1;
+	watch *w2 = (watch *)d2;
+	int n1, n2;
+	n1 = w1->fid->handle.handle_bytes;
+	n2 = w2->fid->handle.handle_bytes;
+	if (n1 != n2) return n1 - n2;
+	return memcmp(w1->fid, w2->fid, sizeof(*(w1->fid)) + n1);
+#else
+	return d1 - d2;
+#endif
+}
+
 int filename_compare(const void *d1, const void *d2, const void *config) {
 	if (!d1 || !d2) return d1 - d2;
 	return strcmp(((watch*)d1)->filename, ((watch*)d2)->filename);
@@ -230,6 +262,15 @@ watch *watch_from_wd( int wd ) {
 	watch w;
 	w.wd = wd;
 	return (watch*)rbfind(&w, tree_wd);
+}
+
+/**
+ * @internal
+ */
+watch *watch_from_fid(struct fanotify_event_fid *fid) {
+	watch w;
+	w.fid = fid;
+	return (watch *)rbfind(&w, tree_fid);
 }
 
 /**
@@ -264,6 +305,7 @@ int inotifytools_initialize() {
 	collect_stats = 0;
 	init = 1;
 	tree_wd = rbinit(wd_compare, 0);
+	tree_fid = rbinit(fid_compare, 0);
 	tree_filename = rbinit(filename_compare, 0);
 	timefmt = 0;
 
@@ -275,6 +317,7 @@ int inotifytools_initialize() {
  */
 void destroy_watch(watch *w) {
 	if (w->filename) free(w->filename);
+	if (w->fid) free(w->fid);
 	free(w);
 }
 
@@ -311,8 +354,12 @@ void inotifytools_cleanup() {
 	}
 
 	rbwalk(tree_wd, cleanup_tree, 0);
-	rbdestroy(tree_wd); tree_wd = 0;
-	rbdestroy(tree_filename); tree_filename = 0;
+	rbdestroy(tree_wd);
+	rbdestroy(tree_fid);
+	rbdestroy(tree_filename);
+	tree_wd = 0;
+	tree_fid = 0;
+	tree_filename = 0;
 }
 
 
@@ -809,13 +856,15 @@ int remove_inotify_watch(watch *w) {
 /**
  * @internal
  */
-watch *create_watch(int wd, char *filename) {
+watch *create_watch(int wd, struct fanotify_event_fid *fid, char *filename) {
 	if ( wd <= 0 || !filename) return 0;
 
 	watch *w = (watch*)calloc(1, sizeof(watch));
-	w->wd = wd;
+	w->wd = wd ?: (unsigned long)fid;
+	w->fid = fid;
 	w->filename = strdup(filename);
 	rbsearch(w, tree_wd);
+	if (fid) rbsearch(w, tree_fid);
 	rbsearch(w, tree_filename);
     return NULL;
 }
@@ -839,6 +888,7 @@ int inotifytools_remove_watch_by_wd( int wd ) {
 
 	if (!remove_inotify_watch(w)) return 0;
 	rbdelete(w, tree_wd);
+	if (w->fid) rbdelete(w, tree_fid);
 	rbdelete(w, tree_filename);
 	destroy_watch(w);
 	return 1;
@@ -862,6 +912,7 @@ int inotifytools_remove_watch_by_filename( char const * filename ) {
 
 	if (!remove_inotify_watch(w)) return 0;
 	rbdelete(w, tree_wd);
+	if (w->fid) rbdelete(w, tree_fid);
 	rbdelete(w, tree_filename);
 	destroy_watch(w);
 	return 1;
@@ -921,6 +972,36 @@ int inotifytools_watch_files( char const * filenames[], int events ) {
 			} // else
 		} // if ( wd < 0 )
 
+		struct fanotify_event_fid *fid = NULL;
+#ifdef LINUX_FANOTIFY
+		if (!wd) {
+			fid = calloc(1, sizeof(*fid) + MAX_FID_LEN);
+			if (!fid) {
+				fprintf(stderr, "Failed to allocate fid");
+				return 0;
+			}
+
+			struct statfs buf;
+			if (statfs(filenames[i], &buf)) {
+				free(fid);
+				fprintf(stderr, "Statfs failed on %s: %s\n",
+					filenames[i], strerror(errno));
+				return 0;
+			}
+			memcpy(&fid->fsid, &buf.f_fsid, sizeof(fid->fsid));
+
+			int ret, mntid;
+			fid->handle.handle_bytes = MAX_FID_LEN;
+			ret = name_to_handle_at(AT_FDCWD, filenames[i],
+						(void *)&fid->handle, &mntid, 0);
+			if (ret || fid->handle.handle_bytes > MAX_FID_LEN) {
+				free(fid);
+				fprintf(stderr, "Encode fid failed on %s: %s\n",
+					filenames[i], strerror(errno));
+				return 0;
+			}
+		}
+#endif
 		char *filename;
 		// Always end filename with / if it is a directory
 		if ( !isdir(filenames[i])
@@ -930,7 +1011,7 @@ int inotifytools_watch_files( char const * filenames[], int events ) {
 		else {
 			nasprintf( &filename, "%s/", filenames[i] );
 		}
-		create_watch(wd, filename);
+		create_watch(wd, fid, filename);
 		free(filename);
 	} // for
 

--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -311,7 +311,8 @@ int inotifytools_init(int fanotify, int watch_filesystem, int verbose) {
 		fanotify_mode = 1;
 		fanotify_mark_type =
 		    watch_filesystem ? FAN_MARK_FILESYSTEM : FAN_MARK_INODE;
-		inotify_fd = fanotify_init(FAN_REPORT_FID, 0);
+		inotify_fd =
+		    fanotify_init(FAN_REPORT_FID | FAN_REPORT_DFID_NAME, 0);
 #endif
 	} else {
 		fanotify_mode = 0;
@@ -1160,7 +1161,8 @@ int inotifytools_watch_files( char const * filenames[], int events ) {
 				flags |= FAN_MARK_DONT_FOLLOW;
 			}
 
-			wd = fanotify_mark(inotify_fd, flags, events,
+			wd = fanotify_mark(inotify_fd, flags,
+					   events | FAN_EVENT_ON_CHILD,
 					   AT_FDCWD, filenames[i]);
 #endif
 		} else {

--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -767,13 +767,13 @@ const char *inotifytools_filename_from_fid(struct fanotify_event_fid *fid) {
 			name_len = 0;  // empty name??
 	}
 
-	if (fanotify_mark_type == FAN_MARK_FILESYSTEM) {
-		// For global watch, try to get path from fid
-		dirfd = open_by_handle_at(mount_fd, &fid->handle, 0);
-		if (dirfd < 0) {
-			fprintf(stderr, "Failed to decode directory fid.\n");
-			return NULL;
-		}
+	// Try to get path from file handle
+	dirfd = open_by_handle_at(mount_fd, &fid->handle, 0);
+	if (dirfd > 0) {
+		// Got path by handle
+	} else if (fanotify_mark_type == FAN_MARK_FILESYSTEM) {
+		fprintf(stderr, "Failed to decode directory fid.\n");
+		return NULL;
 	} else if (name_len) {
 		// For recursive watch look for watch by fid without the name
 		fid->info.hdr.info_type = FAN_EVENT_INFO_TYPE_DFID;

--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -737,6 +737,80 @@ char * inotifytools_event_to_str_sep(int events, char sep)
 }
 
 /**
+ * Get the filename from fid.
+ *
+ * Resolve filename from fid + name and return
+ * static filename string.
+ */
+const char *inotifytools_filename_from_fid(struct fanotify_event_fid *fid) {
+#ifdef LINUX_FANOTIFY
+	static char filename[PATH_MAX];
+	struct fanotify_event_fid fsid = {};
+	int mount_fd = AT_FDCWD;
+
+	// Match mount_fd from fid->fsid (and null fhandle)
+	fsid.info.fsid.val[0] = fid->info.fsid.val[0];
+	fsid.info.fsid.val[1] = fid->info.fsid.val[1];
+	fsid.info.hdr.info_type = FAN_EVENT_INFO_TYPE_FID;
+	fsid.info.hdr.len = sizeof(fsid);
+	watch *mnt = watch_from_fid(&fsid);
+	if (mnt) mount_fd = mnt->wd >> 1;
+
+	int dirfd = open_by_handle_at(mount_fd, &fid->handle, 0);
+	if (dirfd < 0) {
+		fprintf(stderr, "Failed to decode directory fid.\n");
+		return NULL;
+	}
+	char sym[30];
+	sprintf(sym, "/proc/self/fd/%d", dirfd);
+	int len = readlink(sym, filename, PATH_MAX);
+	if (len < 0) {
+		close(dirfd);
+		fprintf(stderr, "Failed to resolve path from directory fid.\n");
+		return NULL;
+	}
+	filename[len++] = '/';
+	filename[len] = 0;
+	if (fid->info.hdr.info_type == FAN_EVENT_INFO_TYPE_DFID_NAME) {
+		int fid_len = sizeof(*fid) + fid->handle.handle_bytes;
+		int name_len = fid->info.hdr.len - fid_len;
+		if (name_len > 0) {
+			const char *name = (const char *)fid->handle.f_handle +
+					   fid->handle.handle_bytes;
+			int deleted = faccessat(dirfd, name, F_OK,
+						AT_SYMLINK_NOFOLLOW);
+			if (deleted && errno != ENOENT) {
+				fprintf(stderr,
+					"Failed to access file %s (%s).\n",
+					name, strerror(errno));
+				close(dirfd);
+				return NULL;
+			}
+			memcpy(filename + len, name, name_len);
+			if (deleted) strcat(filename, " (deleted)");
+		}
+	}
+	close(dirfd);
+	return filename;
+#else
+	return NULL;
+#endif
+}
+
+/**
+ * Get the filename from a watch.
+ *
+ * If not stored in watch, resolve filename from fid + name and return
+ * static filename string.
+ */
+const char *inotifytools_filename_from_watch(watch *w) {
+	if (!w) return "";
+	if (!w->fid || !fanotify_mark_type) return w->filename;
+
+	return inotifytools_filename_from_fid(w->fid) ?: "";
+}
+
+/**
  * Get the filename used to establish a watch.
  *
  * inotifytools_initialize() must be called before this function can
@@ -756,13 +830,13 @@ char * inotifytools_event_to_str_sep(int events, char sep)
  *       Finally, if a file is moved or renamed while being watched, the
  *       filename returned will still be the original name.
  */
-char * inotifytools_filename_from_wd( int wd ) {
+const char *inotifytools_filename_from_wd(int wd) {
 	niceassert( init, "inotifytools_initialize not called yet" );
+	if (!wd) return "";
 	watch *w = watch_from_wd(wd);
-	if (!w)
-        return NULL;
+	if (!w) return "";
 
-	return w->filename;
+	return inotifytools_filename_from_watch(w);
 }
 
 /**
@@ -773,9 +847,9 @@ char * inotifytools_filename_from_wd( int wd ) {
  *
  * The caller should NOT free() the returned string.
  */
-char *inotifytools_dirname_from_event(struct inotify_event *event,
-				      size_t *dirnamelen) {
-	char *filename = inotifytools_filename_from_wd(event->wd);
+const char *inotifytools_dirname_from_event(struct inotify_event *event,
+					    size_t *dirnamelen) {
+	const char *filename = inotifytools_filename_from_wd(event->wd);
 	char *dirsep;
 
 	if (!filename) {
@@ -802,7 +876,7 @@ char *inotifytools_dirname_from_event(struct inotify_event *event,
 char *inotifytools_dirpath_from_event(struct inotify_event *event) {
 	const char *filename = inotifytools_filename_from_wd(event->wd);
 
-	if (!filename || !(event->mask & IN_ISDIR)) {
+	if (!filename || !*filename || !(event->mask & IN_ISDIR)) {
 		return NULL;
 	}
 
@@ -945,10 +1019,10 @@ watch *create_watch(int wd, struct fanotify_event_fid *fid, const char *filename
 	}
 	w->wd = wd ?: (unsigned long)fid;
 	w->fid = fid;
-	w->filename = strdup(filename);
+	if (filename) w->filename = strdup(filename);
 	rbsearch(w, tree_wd);
 	if (fid) rbsearch(w, tree_fid);
-	rbsearch(w, tree_filename);
+	if (filename) rbsearch(w, tree_filename);
 	return w;
 }
 
@@ -1409,64 +1483,29 @@ more_events:
 		ret = &event[MAX_EVENTS];
 		watch *w = watch_from_fid(fid);
 		if (!w) {
-			struct fanotify_event_fid *fsid;
-			int mount_fd = AT_FDCWD;
-
-			fsid = calloc(1, sizeof(*fsid));
-			if (!fsid) {
-				fprintf(stderr, "Failed to allocate fsid");
-				return NULL;
-			}
-			// Match mount_fd from fid->fsid (and null fhandle)
-			fsid->info.fsid.val[0] = fid->info.fsid.val[0];
-			fsid->info.fsid.val[1] = fid->info.fsid.val[1];
-			fsid->info.hdr.info_type = FAN_EVENT_INFO_TYPE_FID;
-			fsid->info.hdr.len = sizeof(*fsid);
-			watch *mnt = watch_from_fid(fsid);
-			if (mnt) mount_fd = mnt->wd >> 1;
-
-			int fd = open_by_handle_at(mount_fd, &fid->handle,
-						   O_PATH);
-			if (fd < 0) {
-				fprintf(stderr, "Failed to decode fid.\n");
-				longjmp(jmp, 0);
-			}
-			char sym[30];
-			sprintf(sym, "/proc/self/fd/%d", fd);
-			char filename[PATH_MAX];
-			int len = readlink(sym, filename, PATH_MAX);
-			close(fd);
-			if (len < 0) {
-				fprintf(stderr,
-					"Failed to resolve path from fid.\n");
-				longjmp(jmp, 0);
-			}
-			filename[len++] = '/';
-			if (name_len > 0) {
-				memcpy(filename + len, name, name_len);
-				len += name_len;
-			}
-			filename[len] = 0;
 			newfid = calloc(1, info->hdr.len);
 			if (!newfid) {
 				fprintf(stderr, "Failed to allocate fid.\n");
 				return NULL;
 			}
 			memcpy(newfid, fid, info->hdr.len);
-			w = create_watch(0, newfid, filename);
-			if (!w) return NULL;
+			const char *filename = inotifytools_filename_from_fid(fid);
+			if (filename) {
+				w = create_watch(0, newfid, filename);
+				if (!w) return NULL;
+			}
 
 			if (verbosity) {
 				unsigned long id;
 				memcpy((void *)&id, fid->handle.f_handle,
 						sizeof(id));
-				printf("Start watching %s (fid=%x.%x.%lx...;"
-				       "name='%s')\n",
-				       ret->name, fid->info.fsid.val[0],
-				       fid->info.fsid.val[1], id, name);
+				printf("[fid=%x.%x.%lx;name='%s'] %s\n",
+				       fid->info.fsid.val[0],
+				       fid->info.fsid.val[1],
+				       id, name, filename ?: "");
 			}
 		}
-		ret->wd = w->wd;
+		ret->wd = w ? w->wd : 0;
 		ret->mask = (uint32_t)meta->mask;
 		ret->len = name_len;
 		if (name_len > 0) memcpy(ret->name, name, name_len);
@@ -1900,7 +1939,8 @@ int inotifytools_sprintf( struct nstring * out, struct inotify_event* event, cha
  */
 int inotifytools_snprintf( struct nstring * out, int size,
                            struct inotify_event* event, char* fmt ) {
-	static char * filename, * eventname, * eventstr;
+	static const char *filename;
+	static char *eventname, *eventstr;
 	static unsigned int i, ind;
 	static char ch1;
 	static char timestr[MAX_STRLEN];

--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -1134,7 +1134,8 @@ struct inotify_event * inotifytools_next_events( long int timeout, int num_event
 
 	if ( num_events < 1 ) return NULL;
 
-	static struct inotify_event event[MAX_EVENTS];
+	// second half of event[] buffer is for fanotify->inotify conversion
+	static struct inotify_event event[2 * MAX_EVENTS];
 	static struct inotify_event * ret;
 	static int first_byte = 0;
 	static ssize_t bytes;
@@ -1249,12 +1250,47 @@ struct inotify_event * inotifytools_next_events( long int timeout, int num_event
 		                "events occurred at once.\n");
 		return NULL;
 	}
-	bytes += this_bytes;
-
 	ret = &event[0];
-	// TODO: get fanotify events
-	if (fanotify_mode) return ret;
+#ifdef LINUX_FANOTIFY
+	// convert fanotify events to inotify events
+	if (fanotify_mode) {
+		struct fanotify_event_metadata *meta = (void *)ret;
+		struct fanotify_event_info_fid *info = (void *)(meta + 1);
+		struct fanotify_event_fid *fid;
+		int fid_len = 0;
 
+		if (meta->event_len > sizeof(*meta) &&
+		    info->hdr.info_type == FAN_EVENT_INFO_TYPE_FID) {
+			fid = (void *)(((char *)info) + sizeof(info->hdr));
+			fid_len = info->hdr.len - sizeof(info->hdr);
+		} else {
+			fprintf(stderr, "No fid in fanotify event.\n");
+			return NULL;
+		}
+		if (verbosity > 1) {
+			printf("fanotify_event: bytes=%ld, first_byte=%d, "
+				"this_bytes=%ld, event_len=%d, fid_len=%d\n",
+				bytes, first_byte, this_bytes,
+				meta->event_len, fid_len);
+		}
+
+		watch *w = watch_from_fid(fid);
+		if (!w) {
+			fprintf(stderr,
+				"Ignoring fanotify event on unwatched "
+				"object.\n");
+			longjmp(jmp, 0);
+		}
+		ret = &event[MAX_EVENTS];
+		ret->wd = w->wd;
+		ret->mask = (uint32_t)meta->mask;
+		ret->len = 0;
+
+		RETURN(ret);
+	}
+#endif
+
+	bytes += this_bytes;
 	first_byte = sizeof(struct inotify_event) + ret->len;
 	niceassert( first_byte <= bytes, "ridiculously long filename, things will "
 	                                 "almost certainly screw up." );

--- a/libinotifytools/src/inotifytools/fanotify-dfid-name.h
+++ b/libinotifytools/src/inotifytools/fanotify-dfid-name.h
@@ -1,0 +1,169 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+#ifndef _LINUX_FANOTIFY_H
+#define _LINUX_FANOTIFY_H
+
+#include <linux/types.h>
+
+/* the following events that user-space can register for */
+#define FAN_ACCESS		0x00000001	/* File was accessed */
+#define FAN_MODIFY		0x00000002	/* File was modified */
+#define FAN_ATTRIB		0x00000004	/* Metadata changed */
+#define FAN_CLOSE_WRITE		0x00000008	/* Writtable file closed */
+#define FAN_CLOSE_NOWRITE	0x00000010	/* Unwrittable file closed */
+#define FAN_OPEN		0x00000020	/* File was opened */
+#define FAN_MOVED_FROM		0x00000040	/* File was moved from X */
+#define FAN_MOVED_TO		0x00000080	/* File was moved to Y */
+#define FAN_CREATE		0x00000100	/* Subfile was created */
+#define FAN_DELETE		0x00000200	/* Subfile was deleted */
+#define FAN_DELETE_SELF		0x00000400	/* Self was deleted */
+#define FAN_MOVE_SELF		0x00000800	/* Self was moved */
+#define FAN_OPEN_EXEC		0x00001000	/* File was opened for exec */
+
+#define FAN_Q_OVERFLOW		0x00004000	/* Event queued overflowed */
+
+#define FAN_OPEN_PERM		0x00010000	/* File open in perm check */
+#define FAN_ACCESS_PERM		0x00020000	/* File accessed in perm check */
+#define FAN_OPEN_EXEC_PERM	0x00040000	/* File open/exec in perm check */
+
+#define FAN_ONDIR		0x40000000	/* event occurred against dir */
+
+#define FAN_EVENT_ON_CHILD	0x08000000	/* interested in child events */
+
+/* helper events */
+#define FAN_CLOSE		(FAN_CLOSE_WRITE | FAN_CLOSE_NOWRITE) /* close */
+#define FAN_MOVE		(FAN_MOVED_FROM | FAN_MOVED_TO) /* moves */
+
+/* flags used for fanotify_init() */
+#define FAN_CLOEXEC		0x00000001
+#define FAN_NONBLOCK		0x00000002
+
+/* These are NOT bitwise flags.  Both bits are used together.  */
+#define FAN_CLASS_NOTIF		0x00000000
+#define FAN_CLASS_CONTENT	0x00000004
+#define FAN_CLASS_PRE_CONTENT	0x00000008
+
+/* Deprecated - do not use this in programs and do not add new flags here! */
+#define FAN_ALL_CLASS_BITS	(FAN_CLASS_NOTIF | FAN_CLASS_CONTENT | \
+				 FAN_CLASS_PRE_CONTENT)
+
+#define FAN_UNLIMITED_QUEUE	0x00000010
+#define FAN_UNLIMITED_MARKS	0x00000020
+#define FAN_ENABLE_AUDIT	0x00000040
+
+/* Flags to determine fanotify event format */
+#define FAN_REPORT_TID		0x00000100	/* event->pid is thread id */
+#define FAN_REPORT_FID		0x00000200	/* Report unique file id */
+#define FAN_REPORT_DIR_FID	0x00000400	/* Report unique directory id */
+#define FAN_REPORT_NAME		0x00000800	/* Report events with name */
+
+/* Convenience macro - FAN_REPORT_NAME requires FAN_REPORT_DIR_FID */
+#define FAN_REPORT_DFID_NAME	(FAN_REPORT_DIR_FID | FAN_REPORT_NAME)
+
+/* Deprecated - do not use this in programs and do not add new flags here! */
+#define FAN_ALL_INIT_FLAGS	(FAN_CLOEXEC | FAN_NONBLOCK | \
+				 FAN_ALL_CLASS_BITS | FAN_UNLIMITED_QUEUE |\
+				 FAN_UNLIMITED_MARKS)
+
+/* flags used for fanotify_modify_mark() */
+#define FAN_MARK_ADD		0x00000001
+#define FAN_MARK_REMOVE		0x00000002
+#define FAN_MARK_DONT_FOLLOW	0x00000004
+#define FAN_MARK_ONLYDIR	0x00000008
+/* FAN_MARK_MOUNT is		0x00000010 */
+#define FAN_MARK_IGNORED_MASK	0x00000020
+#define FAN_MARK_IGNORED_SURV_MODIFY	0x00000040
+#define FAN_MARK_FLUSH		0x00000080
+/* FAN_MARK_FILESYSTEM is	0x00000100 */
+
+/* These are NOT bitwise flags.  Both bits can be used togther.  */
+#define FAN_MARK_INODE		0x00000000
+#define FAN_MARK_MOUNT		0x00000010
+#define FAN_MARK_FILESYSTEM	0x00000100
+
+/* Deprecated - do not use this in programs and do not add new flags here! */
+#define FAN_ALL_MARK_FLAGS	(FAN_MARK_ADD |\
+				 FAN_MARK_REMOVE |\
+				 FAN_MARK_DONT_FOLLOW |\
+				 FAN_MARK_ONLYDIR |\
+				 FAN_MARK_MOUNT |\
+				 FAN_MARK_IGNORED_MASK |\
+				 FAN_MARK_IGNORED_SURV_MODIFY |\
+				 FAN_MARK_FLUSH)
+
+/* Deprecated - do not use this in programs and do not add new flags here! */
+#define FAN_ALL_EVENTS (FAN_ACCESS |\
+			FAN_MODIFY |\
+			FAN_CLOSE |\
+			FAN_OPEN)
+
+/*
+ * All events which require a permission response from userspace
+ */
+/* Deprecated - do not use this in programs and do not add new flags here! */
+#define FAN_ALL_PERM_EVENTS (FAN_OPEN_PERM |\
+			     FAN_ACCESS_PERM)
+
+/* Deprecated - do not use this in programs and do not add new flags here! */
+#define FAN_ALL_OUTGOING_EVENTS	(FAN_ALL_EVENTS |\
+				 FAN_ALL_PERM_EVENTS |\
+				 FAN_Q_OVERFLOW)
+
+#define FANOTIFY_METADATA_VERSION	3
+
+struct fanotify_event_metadata {
+	__u32 event_len;
+	__u8 vers;
+	__u8 reserved;
+	__u16 metadata_len;
+	__aligned_u64 mask;
+	__s32 fd;
+	__s32 pid;
+};
+
+#define FAN_EVENT_INFO_TYPE_FID		1
+#define FAN_EVENT_INFO_TYPE_DFID_NAME	2
+#define FAN_EVENT_INFO_TYPE_DFID	3
+
+/* Variable length info record following event metadata */
+struct fanotify_event_info_header {
+	__u8 info_type;
+	__u8 pad;
+	__u16 len;
+};
+
+/* Unique file identifier info record */
+struct fanotify_event_info_fid {
+	struct fanotify_event_info_header hdr;
+	__kernel_fsid_t fsid;
+	/*
+	 * Following is an opaque struct file_handle that can be passed as
+	 * an argument to open_by_handle_at(2).
+	 */
+	unsigned char handle[0];
+};
+
+struct fanotify_response {
+	__s32 fd;
+	__u32 response;
+};
+
+/* Legit userspace responses to a _PERM event */
+#define FAN_ALLOW	0x01
+#define FAN_DENY	0x02
+#define FAN_AUDIT	0x10	/* Bit mask to create audit record for result */
+
+/* No fd set in event */
+#define FAN_NOFD	-1
+
+/* Helper functions to deal with fanotify_event_metadata buffers */
+#define FAN_EVENT_METADATA_LEN (sizeof(struct fanotify_event_metadata))
+
+#define FAN_EVENT_NEXT(meta, len) ((len) -= (meta)->event_len, \
+				   (struct fanotify_event_metadata*)(((char *)(meta)) + \
+				   (meta)->event_len))
+
+#define FAN_EVENT_OK(meta, len)	((long)(len) >= (long)FAN_EVENT_METADATA_LEN && \
+				(long)(meta)->event_len >= (long)FAN_EVENT_METADATA_LEN && \
+				(long)(meta)->event_len <= (long)(len))
+
+#endif /* _LINUX_FANOTIFY_H */

--- a/libinotifytools/src/inotifytools/fanotify.h.in
+++ b/libinotifytools/src/inotifytools/fanotify.h.in
@@ -1,0 +1,22 @@
+#ifndef _INOTIFYTOOLS_FANOTIFY_H
+#define _INOTIFYTOOLS_FANOTIFY_H 1
+
+/* this is defined to 1 if <sys/fanotify.h> works. */
+#undef SYS_FANOTIFY_H_EXISTS_AND_WORKS
+
+
+#ifdef SYS_FANOTIFY_H_EXISTS_AND_WORKS
+#include <sys/fanotify.h>
+#else
+/*
+ * Assuming sys/fanotify.h does exist, but linux/fanotify.h doesn't have
+ * FAN_REPORT_DFID_NAME, so include our own copy of linux/fanotify.h
+ * before including sys/fanotify.h.
+ */
+#include "fanotify-dfid-name.h"
+#include <sys/fanotify.h>
+#endif // SYS_FANOTIFY_H_EXISTS_AND_WORKS
+
+
+#endif
+

--- a/libinotifytools/src/inotifytools/inotifytools.h
+++ b/libinotifytools/src/inotifytools/inotifytools.h
@@ -37,10 +37,12 @@ void inotifytools_set_filename_by_filename( char const * oldname,
 void inotifytools_replace_filename( char const * oldname,
                                     char const * newname );
 struct inotify_event;
-char *inotifytools_dirname_from_event(struct inotify_event *event,
-				      size_t *dirnamelen);
+const char *inotifytools_dirname_from_event(struct inotify_event *event,
+					    size_t *dirnamelen);
 char *inotifytools_dirpath_from_event(struct inotify_event *event);
-char *inotifytools_filename_from_wd(int wd);
+struct watch;
+const char *inotifytools_filename_from_watch(struct watch *w);
+const char *inotifytools_filename_from_wd(int wd);
 int inotifytools_wd_from_filename( char const * filename );
 int inotifytools_remove_watch_by_filename( char const * filename );
 int inotifytools_remove_watch_by_wd( int wd );

--- a/libinotifytools/src/inotifytools/inotifytools.h
+++ b/libinotifytools/src/inotifytools/inotifytools.h
@@ -58,7 +58,7 @@ int inotifytools_get_stat_by_filename( char const * filename,
                                                 int event );
 void inotifytools_initialize_stats();
 int inotifytools_initialize();
-int inotifytools_init(int fanotify, int verbose);
+int inotifytools_init(int fanotify, int watch_filesystem, int verbose);
 void inotifytools_cleanup();
 int inotifytools_get_num_watches();
 

--- a/libinotifytools/src/inotifytools/inotifytools.h
+++ b/libinotifytools/src/inotifytools/inotifytools.h
@@ -37,8 +37,10 @@ void inotifytools_set_filename_by_filename( char const * oldname,
 void inotifytools_replace_filename( char const * oldname,
                                     char const * newname );
 struct inotify_event;
+char *inotifytools_dirname_from_event(struct inotify_event *event,
+				      size_t *dirnamelen);
 char *inotifytools_dirpath_from_event(struct inotify_event *event);
-char * inotifytools_filename_from_wd( int wd );
+char *inotifytools_filename_from_wd(int wd);
 int inotifytools_wd_from_filename( char const * filename );
 int inotifytools_remove_watch_by_filename( char const * filename );
 int inotifytools_remove_watch_by_wd( int wd );

--- a/libinotifytools/src/inotifytools/inotifytools.h
+++ b/libinotifytools/src/inotifytools/inotifytools.h
@@ -58,6 +58,7 @@ int inotifytools_get_stat_by_filename( char const * filename,
                                                 int event );
 void inotifytools_initialize_stats();
 int inotifytools_initialize();
+int inotifytools_init(int fanotify, int verbose);
 void inotifytools_cleanup();
 int inotifytools_get_num_watches();
 

--- a/libinotifytools/src/inotifytools/inotifytools.h
+++ b/libinotifytools/src/inotifytools/inotifytools.h
@@ -36,6 +36,8 @@ void inotifytools_set_filename_by_filename( char const * oldname,
                                             char const * newname );
 void inotifytools_replace_filename( char const * oldname,
                                     char const * newname );
+struct inotify_event;
+char *inotifytools_dirpath_from_event(struct inotify_event *event);
 char * inotifytools_filename_from_wd( int wd );
 int inotifytools_wd_from_filename( char const * filename );
 int inotifytools_remove_watch_by_filename( char const * filename );

--- a/libinotifytools/src/inotifytools_p.h
+++ b/libinotifytools/src/inotifytools_p.h
@@ -46,9 +46,15 @@ void _niceassert( long cond, int line, char const * file,
 
 struct rbtree *inotifytools_wd_sorted_by_event(int sort_event);
 extern int init;
+
+struct fanotify_event_fid;
+
+#define MAX_FID_LEN 20
+
 typedef struct watch {
+	struct fanotify_event_fid *fid;
 	char *filename;
-	int wd;
+	unsigned long wd;
 	unsigned hit_access;
 	unsigned hit_modify;
 	unsigned hit_attrib;

--- a/libinotifytools/src/inotifytools_p.h
+++ b/libinotifytools/src/inotifytools_p.h
@@ -55,6 +55,7 @@ typedef struct watch {
 	struct fanotify_event_fid *fid;
 	char *filename;
 	unsigned long wd;
+	int dirfd;
 	unsigned hit_access;
 	unsigned hit_modify;
 	unsigned hit_attrib;

--- a/libinotifytools/src/test.c
+++ b/libinotifytools/src/test.c
@@ -182,14 +182,14 @@ void basic_watch_info() {
     verify(!strcmp(inotifytools_filename_from_wd(1), "/"));
     verify(inotifytools_remove_watch_by_filename("/"));
     compare(inotifytools_wd_from_filename("/"), -1);
-    compare(inotifytools_filename_from_wd(1), 0);
+    compare(*inotifytools_filename_from_wd(1), 0);
     verify(inotifytools_watch_file("/", IN_CLOSE));
     compare(inotifytools_wd_from_filename("/"), 2);
     compare(inotifytools_wd_from_filename("foobar"), -1);
     verify(!strcmp(inotifytools_filename_from_wd(2), "/"));
     verify(inotifytools_remove_watch_by_wd(2));
     compare(inotifytools_wd_from_filename("/"), -1);
-    compare(inotifytools_filename_from_wd(2), 0);
+    compare(*inotifytools_filename_from_wd(2), 0);
     EXIT
 }
 

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,1 +1,1 @@
-dist_man_MANS = inotifywait.1 inotifywatch.1
+dist_man_MANS = inotifywait.1 inotifywatch.1 fsnotifywait.1 fsnotifywatch.1

--- a/man/fsnotifywait.1.in
+++ b/man/fsnotifywait.1.in
@@ -1,0 +1,1 @@
+.so man1/inotifywait.1

--- a/man/fsnotifywatch.1.in
+++ b/man/fsnotifywatch.1.in
@@ -1,0 +1,1 @@
+.so man1/inotifywatch.1

--- a/man/inotifywait.1.in
+++ b/man/inotifywait.1.in
@@ -5,7 +5,7 @@ inotifywait \- wait for changes to files using inotify
 
 .SH SYNOPSIS
 .B inotifywait
-.RB [ \-hcmrPq ]
+.RB [ \-hcmrPqS ]
 .RB [ \-e
 <event> ]
 .RB [ \-t
@@ -200,6 +200,10 @@ Replaced with NUL.
 .TP
 %n
 Replaced with Line Feed.
+
+.TP
+.B \-S, \-\-filesystem
+Watch entire filesystem of any directories passed as arguments using fanotify.
 
 
 

--- a/man/inotifywait.1.in
+++ b/man/inotifywait.1.in
@@ -1,10 +1,22 @@
 .TH inotifywait 1 "@MAN_DATE@" "inotifywait @MAN_PACKAGE_VERSION@"
 
 .SH NAME
-inotifywait \- wait for changes to files using inotify
+inotifywait, fsnotifywait \- wait for changes to files using inotify or fanotify
 
 .SH SYNOPSIS
 .B inotifywait
+.RB [ \-hcmrPq ]
+.RB [ \-e
+<event> ]
+.RB [ \-t
+<seconds> ]
+.RB [ \-\-format
+<fmt> ]
+.RB [ \-\-timefmt
+<fmt> ]
+<file> [ ... ]
+
+.B fsnotifywait
 .RB [ \-hcmrPqIFS ]
 .RB [ \-e
 <event> ]
@@ -16,6 +28,7 @@ inotifywait \- wait for changes to files using inotify
 <fmt> ]
 <file> [ ... ]
 
+
 .SH DESCRIPTION
 .B inotifywait
 efficiently waits for changes to files using Linux's
@@ -24,8 +37,19 @@ interface.  It is suitable for waiting for changes to files from shell scripts.
 It can either exit once an event occurs, or continually execute and output events
 as they occur.
 
+.B fsnotifywait
+is similar to
+.B inotifywait
+but it is using Linux's
+.BR fanotify(7)
+interface by default. If explicitly sepcified, it uses the
+.BR inotify(7)
+interface.
+
 .SH OUTPUT
 .B inotifywait
+and
+.B fsnotifywait
 will output diagnostic information on standard error and event information on
 standard output.  The event output can be configured, but by default it
 consists of lines of the following form:
@@ -201,13 +225,18 @@ Replaced with NUL.
 %n
 Replaced with Line Feed.
 
+.\"
+.SS fsnotifywait
+
+.PP
+The following additional options are available:
 .TP
 .B \-I, \-\-inotify
 Watch using inotify.
 
 .TP
 .B \-F, \-\-fanotify
-Watch using fanotify.
+Watch using fanotify (default).
 fanotify support for reporting events with inotify compatible information
 was added in kernel v5.9.  With older kernels the command will fail.
 As of kernel v5.12, fanotify requires admin privileges.

--- a/man/inotifywait.1.in
+++ b/man/inotifywait.1.in
@@ -5,7 +5,7 @@ inotifywait \- wait for changes to files using inotify
 
 .SH SYNOPSIS
 .B inotifywait
-.RB [ \-hcmrPqS ]
+.RB [ \-hcmrPqIFS ]
 .RB [ \-e
 <event> ]
 .RB [ \-t
@@ -200,6 +200,17 @@ Replaced with NUL.
 .TP
 %n
 Replaced with Line Feed.
+
+.TP
+.B \-I, \-\-inotify
+Watch using inotify.
+
+.TP
+.B \-F, \-\-fanotify
+Watch using fanotify.
+fanotify support for reporting events with inotify compatible information
+was added in kernel v5.9.  With older kernels the command will fail.
+As of kernel v5.12, fanotify requires admin privileges.
 
 .TP
 .B \-S, \-\-filesystem

--- a/man/inotifywatch.1.in
+++ b/man/inotifywatch.1.in
@@ -1,10 +1,23 @@
 .TH inotifywatch 1 "@MAN_DATE@" "inotifywatch @MAN_PACKAGE_VERSION@"
 
 .SH NAME
-inotifywatch \- gather filesystem access statistics using inotify
+inotifywatch, fsnotifywatch \- gather filesystem access statistics using inotify
+or fanotify
 
 .SH SYNOPSIS
 .B inotifywatch
+.RB [ \-hvzrPqf ]
+.RB [ \-e
+<event> ]
+.RB [ \-t
+<seconds> ]
+.RB [ \-a
+<event> ]
+.RB [ \-d
+<event> ]
+<file> [ ... ]
+
+.B fsnotifywatch
 .RB [ \-hvzrPqfIFS ]
 .RB [ \-e
 <event> ]
@@ -23,8 +36,19 @@ listens for filesystem events using Linux's
 interface, then outputs a summary count of the events received on each file or
 directory.
 
+.B fsnotifywatch
+is similar to
+.B inotifywatch
+but it is using Linux's
+.BR fanotify(7)
+interface by default. If explicitly sepcified, it uses the
+.BR inotify(7)
+interface.
+
 .SH OUTPUT
 .B inotifywatch
+and
+.B fsnotifywatch
 will output a table on standard out with one column for each type of event and
 one row for each watched file or directory.  The table will show the amount of
 times each event occurred for each watched file or directory.  Output can be
@@ -239,13 +263,19 @@ The filesystem on which a watched file or directory resides was unmounted.
 After this event the file or directory is no longer being watched.  Note that
 this event can occur even if it is not explicitly being listened to.
 
+.\"
+.SS fsnotifywatch
+
+.PP
+The following additional options are available:
+.TP
 .TP
 .B \-I, \-\-inotify
 Watch using inotify.
 
 .TP
 .B \-F, \-\-fanotify
-Watch using fanotify.
+Watch using fanotify (default).
 fanotify support for reporting events with inotify compatible information
 was added in kernel v5.9.  With older kernels the command will fail.
 As of kernel v5.12, fanotify requires admin privileges.

--- a/man/inotifywatch.1.in
+++ b/man/inotifywatch.1.in
@@ -5,7 +5,7 @@ inotifywatch \- gather filesystem access statistics using inotify
 
 .SH SYNOPSIS
 .B inotifywatch
-.RB [ \-hvzrPqf ]
+.RB [ \-hvzrPqfS ]
 .RB [ \-e
 <event> ]
 .RB [ \-t
@@ -238,6 +238,10 @@ explicitly being listened for.
 The filesystem on which a watched file or directory resides was unmounted.
 After this event the file or directory is no longer being watched.  Note that
 this event can occur even if it is not explicitly being listened to.
+
+.TP
+.B \-S, \-\-filesystem
+Watch entire filesystem of any directories passed as arguments using fanotify.
 
 
 .SH EXAMPLE

--- a/man/inotifywatch.1.in
+++ b/man/inotifywatch.1.in
@@ -5,7 +5,7 @@ inotifywatch \- gather filesystem access statistics using inotify
 
 .SH SYNOPSIS
 .B inotifywatch
-.RB [ \-hvzrPqfS ]
+.RB [ \-hvzrPqfIFS ]
 .RB [ \-e
 <event> ]
 .RB [ \-t
@@ -238,6 +238,17 @@ explicitly being listened for.
 The filesystem on which a watched file or directory resides was unmounted.
 After this event the file or directory is no longer being watched.  Note that
 this event can occur even if it is not explicitly being listened to.
+
+.TP
+.B \-I, \-\-inotify
+Watch using inotify.
+
+.TP
+.B \-F, \-\-fanotify
+Watch using fanotify.
+fanotify support for reporting events with inotify compatible information
+was added in kernel v5.9.  With older kernels the command will fail.
+As of kernel v5.12, fanotify requires admin privileges.
 
 .TP
 .B \-S, \-\-filesystem

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,6 +2,15 @@ bin_PROGRAMS = inotifywait inotifywatch
 inotifywait_SOURCES = inotifywait.c common.c common.h
 inotifywatch_SOURCES = inotifywatch.c common.c common.h
 
+if ENABLE_FANOTIFY
+# Build the fsnotify* tools with fanotify as the default backend
+bin_PROGRAMS += fsnotifywait fsnotifywatch
+fsnotifywait_SOURCES = inotifywait.c common.c common.h
+fsnotifywait_CPPFLAGS = -DENABLE_FANOTIFY
+fsnotifywatch_SOURCES = inotifywatch.c common.c common.h
+fsnotifywatch_CPPFLAGS = -DENABLE_FANOTIFY
+endif
+
 AM_CFLAGS = -Wall -Wextra -Wshadow -Wpointer-arith -Werror -std=c99 -I../libinotifytools/src
 AM_CPPFLAGS = -I$(top_srcdir)/libinotifytools/src
 LDADD = ../libinotifytools/src/libinotifytools.la

--- a/src/common.h
+++ b/src/common.h
@@ -4,6 +4,9 @@
 #ifdef __FreeBSD__
 #define stat64 stat
 #define lstat64 lstat
+#ifdef DEFAULT_FANOTIFY
+#error "FreeBSD does not support fanotify"
+#endif
 #endif
 
 #include <stdbool.h>
@@ -16,6 +19,12 @@
 #endif
 #define EXIT_TIMEOUT 2
 
+#ifdef DEFAULT_FANOTIFY
+#define DEFAULT_FANOTIFY_MODE 1
+#else
+#define DEFAULT_FANOTIFY_MODE 0
+#endif
+
 void print_event_descriptions();
 int isdir(char const *path);
 
@@ -25,7 +34,7 @@ typedef struct {
 } FileList;
 FileList construct_path_list(int argc, char **argv, char const *filename);
 
-void warn_inotify_init_error();
+void warn_inotify_init_error(int fanotify);
 
 bool is_timeout_option_valid(long int *timeout, char *optarg);
 

--- a/src/common.h
+++ b/src/common.h
@@ -4,7 +4,7 @@
 #ifdef __FreeBSD__
 #define stat64 stat
 #define lstat64 lstat
-#ifdef DEFAULT_FANOTIFY
+#ifdef ENABLE_FANOTIFY
 #error "FreeBSD does not support fanotify"
 #endif
 #endif
@@ -19,9 +19,13 @@
 #endif
 #define EXIT_TIMEOUT 2
 
-#ifdef DEFAULT_FANOTIFY
+#ifdef ENABLE_FANOTIFY
+// fsnotifywait/fsnotifywatch defaults to fanotify
+#define TOOLS_PREFIX "fsnotify"
 #define DEFAULT_FANOTIFY_MODE 1
 #else
+// inotifywait/inotifywatch defaults to inotify
+#define TOOLS_PREFIX "inotify"
 #define DEFAULT_FANOTIFY_MODE 0
 #endif
 

--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -547,6 +547,7 @@ bool parse_opts(int *argc, char ***argv, int *events, bool *monitor, int *quiet,
             (*recursive)++;
             break;
 
+#ifdef ENABLE_FANOTIFY
         // --inotify or -I
         case 'I':
             (*fanotify) = 0;
@@ -562,6 +563,7 @@ bool parse_opts(int *argc, char ***argv, int *events, bool *monitor, int *quiet,
             (*filesystem) = true;
             (*fanotify) = 1;
             break;
+#endif
 
         // --csv or -c
         case 'c':
@@ -744,11 +746,13 @@ bool parse_opts(int *argc, char ***argv, int *events, bool *monitor, int *quiet,
     return (curr_opt != '?');
 }
 
+#define TOOL_NAME TOOLS_PREFIX "wait"
+
 void print_help() {
-    printf("inotifywait %s\n", PACKAGE_VERSION);
+    printf("%s %s\n", TOOL_NAME, PACKAGE_VERSION);
     printf("Wait for a particular event on a file or set of files.\n");
-    printf("Usage: inotifywait [ options ] file1 [ file2 ] [ file3 ] "
-           "[ ... ]\n");
+    printf("Usage: %s [ options ] file1 [ file2 ] [ file3 ] [ ... ]\n",
+           TOOL_NAME);
     printf("Options:\n");
     printf("\t-h|--help     \tShow this help text.\n");
     printf("\t@<file>       \tExclude the specified file from being "
@@ -768,8 +772,8 @@ void print_help() {
            "\t              \tLike --include but case insensitive.\n");
     printf("\t-m|--monitor  \tKeep listening for events forever or until "
            "--timeout expires.\n"
-           "\t              \tWithout this option, inotifywait will exit after "
-           "one event is received.\n");
+           "\t              \tWithout this option, %s will exit after "
+           "one event is received.\n", TOOL_NAME);
     printf(
         "\t-d|--daemon   \tSame as --monitor, except run in the background\n"
         "\t              \tlogging events to a file specified by --outfile.\n"
@@ -777,9 +781,11 @@ void print_help() {
     printf("\t-P|--no-dereference\n"
            "\t              \tDo not follow symlinks.\n");
     printf("\t-r|--recursive\tWatch directories recursively.\n");
+#ifdef ENABLE_FANOTIFY
     printf("\t-I|--inotify\tWatch with inotify.\n");
     printf("\t-F|--fanotify\tWatch with fanotify.\n");
     printf("\t-S|--filesystem\tWatch entire filesystem with fanotify.\n");
+#endif
     printf("\t--fromfile <file>\n"
            "\t              \tRead files to watch from <file> or `-' for "
            "stdin.\n");
@@ -799,9 +805,8 @@ void print_help() {
            "\t              \tWhen listening for a single event, time out "
            "after\n"
            "\t              \twaiting for an event for <seconds> seconds.\n"
-           "\t              \tIf <seconds> is negative, inotifywait will never "
-           "time "
-           "out.\n");
+           "\t              \tIf <seconds> is negative, %s will never time "
+           "out.\n", TOOL_NAME);
     printf("\t-e|--event <event1> [ -e|--event <event2> ... ]\n"
            "\t\tListen for specific event(s).  If omitted, all events are \n"
            "\t\tlistened for.\n\n");

--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -43,7 +43,7 @@ bool parse_opts(int *argc, char ***argv, int *events, bool *monitor, int *quiet,
 
 void print_help();
 
-static char *csv_escape_len(char *string, size_t len) {
+static char *csv_escape_len(const char *string, size_t len) {
     static char csv[MAX_STRLEN + 1];
     static unsigned int i, ind;
 
@@ -77,7 +77,7 @@ static char *csv_escape_len(char *string, size_t len) {
     return csv;
 }
 
-static char *csv_escape(char *string) {
+static char *csv_escape(const char *string) {
     if (string == NULL) {
         return NULL;
     }
@@ -113,7 +113,7 @@ void validate_format(char *fmt) {
 
 void output_event_csv(struct inotify_event *event) {
     size_t dirnamelen = 0;
-    char *dirname = inotifytools_dirname_from_event(event, &dirnamelen);
+    const char *dirname = inotifytools_dirname_from_event(event, &dirnamelen);
     char *filename = csv_escape_len(dirname, dirnamelen);
     if (filename != NULL)
         printf("%s,", filename);

--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -369,7 +369,7 @@ int main(int argc, char **argv) {
             }
         }
 
-        // TODO: index files from unknown watches
+        // TODO: replace filename of renamed filesystem watch entries
         if (filesystem)
             continue;
 

--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -394,13 +394,8 @@ int main(int argc, char **argv) {
             if ((event->mask & IN_CREATE) ||
                 (!moved_from && (event->mask & IN_MOVED_TO))) {
                 // New file - if it is a directory, watch it
-                static char *new_file;
-
-                nasprintf(&new_file, "%s%s",
-                          inotifytools_filename_from_wd(event->wd),
-                          event->name);
-
-                if (isdir(new_file) &&
+                char *new_file = inotifytools_dirpath_from_event(event);
+                if (new_file && *new_file && isdir(new_file) &&
                     !inotifytools_watch_recursively(new_file, events)) {
                     output_error(syslog,
                                  "Couldn't watch new directory %s: %s\n",
@@ -409,9 +404,7 @@ int main(int argc, char **argv) {
                 free(new_file);
             } // IN_CREATE
             else if (event->mask & IN_MOVED_FROM) {
-                nasprintf(&moved_from, "%s%s/",
-                          inotifytools_filename_from_wd(event->wd),
-                          event->name);
+                moved_from = inotifytools_dirpath_from_event(event);
                 // if not watched...
                 if (inotifytools_wd_from_filename(moved_from) == -1) {
                     free(moved_from);
@@ -420,11 +413,9 @@ int main(int argc, char **argv) {
             } // IN_MOVED_FROM
             else if (event->mask & IN_MOVED_TO) {
                 if (moved_from) {
-                    static char *new_name;
-                    nasprintf(&new_name, "%s%s/",
-                              inotifytools_filename_from_wd(event->wd),
-                              event->name);
+                    char *new_name = inotifytools_dirpath_from_event(event);
                     inotifytools_replace_filename(moved_from, new_name);
+                    free(new_name);
                     free(moved_from);
                     moved_from = 0;
                 } // moved_from

--- a/src/inotifywatch.c
+++ b/src/inotifywatch.c
@@ -373,7 +373,7 @@ int print_info() {
             (zero || inotifytools_get_stat_total(IN_UNMOUNT)))
             printf("%-7u  ", w->hit_unmount);
 
-        printf("%s\n", w->filename);
+        printf("%s\n", inotifytools_filename_from_watch(w));
         w = (watch *)rbreadlist(rblist);
     }
     rbcloselist(rblist);

--- a/src/inotifywatch.c
+++ b/src/inotifywatch.c
@@ -217,7 +217,7 @@ int main(int argc, char **argv) {
             }
         }
 
-        // TODO: index files from unknown watches
+        // TODO: replace filename of renamed filesystem watch entries
         if (filesystem)
             continue;
 

--- a/src/inotifywatch.c
+++ b/src/inotifywatch.c
@@ -465,6 +465,7 @@ bool parse_opts(int *argc, char ***argv, int *e, long int *timeout,
             ++(*recursive);
             break;
 
+#ifdef ENABLE_FANOTIFY
         // --inotify or -I
         case 'I':
             (*fanotify) = 0;
@@ -480,6 +481,7 @@ bool parse_opts(int *argc, char ***argv, int *e, long int *timeout,
             (*filesystem) = true;
             (*fanotify) = 1;
             break;
+#endif
 
         case 'P':
             ++(*no_dereference);
@@ -633,10 +635,12 @@ bool parse_opts(int *argc, char ***argv, int *e, long int *timeout,
     return (curr_opt != '?');
 }
 
+#define TOOL_NAME TOOLS_PREFIX "watch"
+
 void print_help() {
-    printf("inotifywatch %s\n", PACKAGE_VERSION);
-    printf("Gather filesystem usage statistics using inotify.\n");
-    printf("Usage: inotifywatch [ options ] file1 [ file2 ] [ ... ]\n");
+    printf("%s %s\n", TOOL_NAME, PACKAGE_VERSION);
+    printf("Gather filesystem usage statistics using %s.\n", TOOL_NAME);
+    printf("Usage: %s [ options ] file1 [ file2 ] [ ... ]\n", TOOL_NAME);
     printf("Options:\n");
     printf("\t-h|--help    \tShow this help text.\n");
     printf("\t-v|--verbose \tBe verbose.\n");
@@ -660,16 +664,17 @@ void print_help() {
            "\t\tif they consist only of zeros (the default is to not output\n"
            "\t\tthese rows and columns).\n");
     printf("\t-r|--recursive\tWatch directories recursively.\n");
+#ifdef ENABLE_FANOTIFY
     printf("\t-I|--inotify\tWatch with inotify.\n");
     printf("\t-F|--fanotify\tWatch with fanotify.\n");
     printf("\t-S|--filesystem\tWatch entire filesystem with fanotify.\n");
+#endif
     printf("\t-P|--no-dereference\n"
            "\t\tDo not follow symlinks.\n");
     printf("\t-t|--timeout <seconds>\n"
            "\t\tListen only for specified amount of time in seconds; if\n"
-           "\t\tomitted or negative, inotifywatch will execute until receiving "
-           "an\n"
-           "\t\tinterrupt signal.\n");
+           "\t\tomitted or negative, %s will execute until receiving an\n"
+           "\t\tinterrupt signal.\n", TOOL_NAME);
     printf("\t-e|--event <event1> [ -e|--event <event2> ... ]\n"
            "\t\tListen for specific event(s).  If omitted, all events are \n"
            "\t\tlistened for.\n");

--- a/t/fanotify-common.sh
+++ b/t/fanotify-common.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Check for kernel support and privileges
+fanotify_supported() {
+    ../../src/fsnotifywait --fanotify 2>&1 | grep -q 'No files specified'
+}

--- a/t/fanotify-common.sh
+++ b/t/fanotify-common.sh
@@ -2,5 +2,16 @@
 
 # Check for kernel support and privileges
 fanotify_supported() {
-    ../../src/fsnotifywait --fanotify 2>&1 | grep -q 'No files specified'
+    ../../src/fsnotifywait --fanotify $* 2>&1 | grep -q 'No files specified'
+}
+
+# Create and mount a test filesystem
+mount_filesystem() {
+    fstype=$1
+    size=$2
+    mnt=$3
+    rm -f img
+    truncate -s $size img && mkfs.$fstype img && \
+        mkdir -p $mnt && mount -o loop img $mnt && \
+        df -t $fstype $mnt
 }

--- a/t/fsnotifywait-subtree.t
+++ b/t/fsnotifywait-subtree.t
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+test_description='Subtree watch
+
+Verify that fsnotifywait --recursive/--filesystem gets events on
+files created inside the watched subtree
+'
+
+. ./fanotify-common.sh
+. ./sharness.sh
+
+logfile="log"
+
+run_() {
+    export LD_LIBRARY_PATH="../../libinotifytools/src/"
+    testdir=root/A/B/C/D
+    rm -rf root/A &&
+        mkdir -p $testdir &&
+	{(sleep 1 && touch $testdir/test)&} &&
+    ../../src/$* \
+        --quiet \
+        --outfile $logfile \
+        --event CREATE \
+        --timeout 2 \
+        root
+}
+
+run_and_check_log()
+{
+    rm -f $logfile
+    run_ $* && grep 'CREATE.test$' $logfile
+}
+
+test_expect_success 'event logged' '
+    run_and_check_log inotifywait --recursive
+'
+
+if fanotify_supported; then
+    test_expect_success 'event logged' '
+        run_and_check_log fsnotifywait --fanotify --recursive
+    '
+fi
+
+if fanotify_supported --filesystem; then
+    test_expect_success 'event logged' '
+        test_when_finished "umount -l root" &&
+        mount_filesystem ext2 10M root &&
+        run_and_check_log fsnotifywait --filesystem
+    '
+fi
+
+test_done

--- a/t/inotifywait-daemon-logs-to-relative-paths.t
+++ b/t/inotifywait-daemon-logs-to-relative-paths.t
@@ -6,6 +6,7 @@ When --daemon is used, events are logged correctly to --outfile
 even if that is a relative path
 '
 
+. ./fanotify-common.sh
 . ./sharness.sh
 
 logfile="log"
@@ -18,7 +19,7 @@ run_() {
     {(sleep 1 && chmod 777 test-file)&} &&
 
     export LD_LIBRARY_PATH="../../libinotifytools/src/"
-    ../../src/inotifywait \
+    ../../src/$* \
         --quiet \
         --daemon \
         --outfile $logfile \
@@ -30,9 +31,20 @@ run_() {
     sleep $timeout
 }
 
+run_and_check_log()
+{
+    rm -f $logfile
+    run_ $* && grep ATTRIB $logfile
+}
+
 test_expect_success 'event logged' '
-    run_ &&
-    grep ATTRIB $logfile
+    run_and_check_log inotifywait
 '
+
+if fanotify_supported; then
+    test_expect_success 'event logged' '
+	run_and_check_log fsnotifywait --fanotify
+    '
+fi
 
 test_done

--- a/t/inotifywait-no-dereference-ignore-symlinked-file.t
+++ b/t/inotifywait-no-dereference-ignore-symlinked-file.t
@@ -2,18 +2,26 @@
 
 test_description='--no-dereference causes inotifywait to ignore events on symlink target'
 
+. ./fanotify-common.sh
 . ./sharness.sh
 
 run_() {
     export LD_LIBRARY_PATH="../../libinotifytools/src/"
+    rm -f test-symlink
     touch test &&
 	ln -s test test-symlink &&
 	{(sleep 1 && touch test)&} &&
-    ../../src/inotifywait --quiet --no-dereference --timeout 2 test-symlink
+    ../../src/$* --quiet --no-dereference --timeout 2 test-symlink
 }
 
 test_expect_success 'Exit code 2 is returned' '
-    test_expect_code 2 run_
+    test_expect_code 2 run_ inotifywait
 '
+
+if fanotify_supported; then
+    test_expect_success 'Exit code 2 is returned' '
+        test_expect_code 2 run_ fsnotifywait --fanotify
+    '
+fi
 
 test_done

--- a/t/inotifywait-no-dereference-respond-to-symlink-event.t
+++ b/t/inotifywait-no-dereference-respond-to-symlink-event.t
@@ -2,18 +2,26 @@
 
 test_description='--no-dereference causes inotifywait to respond to events on symlink'
 
+. ./fanotify-common.sh
 . ./sharness.sh
 
 run_() {
     export LD_LIBRARY_PATH="../../libinotifytools/src/"
+    rm -f test-symlink
     touch test &&
 	ln -s test test-symlink &&
 	{(sleep 1 && touch -h test-symlink)&} &&
-    ../../src/inotifywait --quiet --no-dereference --timeout 2 test-symlink
+    ../../src/$* --quiet --no-dereference --timeout 2 test-symlink
 }
 
 test_expect_success 'Exit code 0 is returned' '
-    run_
+    run_ inotifywait
 '
+
+if fanotify_supported; then
+    test_expect_success 'Exit code 0 is returned' '
+        run_ fsnotifywait --fanotify
+    '
+fi
 
 test_done

--- a/t/inotifywait-no-event-occured.t
+++ b/t/inotifywait-no-event-occured.t
@@ -2,16 +2,23 @@
 
 test_description='No event occured for inotifywait'
 
+. ./fanotify-common.sh
 . ./sharness.sh
 
 run_() {
     export LD_LIBRARY_PATH="../../libinotifytools/src/"
     touch test &&
-    ../../src/inotifywait --quiet --timeout 1 test
+    ../../src/$* --quiet --timeout 1 test
 }
 
 test_expect_success 'Exit code 2 is returned' '
-    test_expect_code 2 run_
+    test_expect_code 2 run_ inotifywait
 '
+
+if fanotify_supported; then
+    test_expect_success 'Exit code 2 is returned' '
+        test_expect_code 2 run_ fsnotifywait --fanotify
+    '
+fi
 
 test_done


### PR DESCRIPTION
* Build alternative tools fsfnotifywait and fsnotifywatch
* The alternative tools auto detect and use fanotify instead of inotify on new kernels (>=v5.9)
* The alternative tools enable watching an entire filesystem without setting up recursive watches
* Setting up fanotify filesystem watches require admin privileges 