### PR TITLE
Document that files are handled by their inodes

### DIFF
--- a/man/inotifywait.1.in
+++ b/man/inotifywait.1.in
@@ -412,6 +412,14 @@ inotifywait -qmr -e 'moved_to,create' --format '%w%f%0' --no-newline ~/test |\\
     done
 .fi
 
+.SH CAVEATS
+
+When using inotifywait, the filename that is outputted is not
+guaranteed to be up to date after a move because it is the inode that
+is being monitored. Additionally, none of the observed operations are
+guaranteed to have been performed on the filename inotifywait was
+instructed to monitor in cases when the file is known by several names
+in the filesystem.
 
 .SH BUGS
 There are race conditions in the recursive directory watching code

--- a/man/inotifywatch.1.in
+++ b/man/inotifywatch.1.in
@@ -313,6 +313,15 @@ total  access  modify  filename
 2      2       0       /home/rohan/.beagle/Indexes/KMailIndex/SecondaryIndex/
 .fi
 
+.SH CAVEATS
+
+When using inotifywatch, the filename that is outputted is not
+guaranteed to be up to date after a move because it is the inode that
+is being monitored. Additionally, none of the observed operations are
+guaranteed to have been performed on the filename inotifywatch was
+instructed to monitor in cases when the file is known by several names
+in the filesystem.
+
 .SH BUGS
 There are race conditions in the recursive directory watching code
 which can cause events to be missed if they occur in a directory immediately


### PR DESCRIPTION
This patch adds a new section in manpages to explain about files and their inodes.

Patch from Debian. Original author: Ondřej Kuzník \<ondra@mistotebe.net\>.

Please, see more details here[1].

[1] https://bugs.debian.org/594163

Thanks!

Eriberto
