### PR TITLE
Fix compile error of 'ssize_t' on 32-bits platform. 

### DIFF
--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -1548,8 +1548,8 @@ more_events:
 		}
 		if (verbosity > 1) {
 			printf(
-			    "fanotify_event: bytes=%ld, first_byte=%d, "
-			    "this_bytes=%ld, event_len=%d, fid_len=%d, "
+			    "fanotify_event: bytes=%zd, first_byte=%d, "
+			    "this_bytes=%zd, event_len=%d, fid_len=%d, "
 			    "name_len=%d, name=%s\n",
 			    bytes, first_byte, this_bytes, meta->event_len,
 			    fid_len, name_len, name);


### PR DESCRIPTION
Fix compile error of 'ssize_t' when cross-compile a 32-bits arm edition of inotify-tools