### PR TITLE
update path for includes in stats.h

### DIFF
--- a/libinotifytools/src/stats.h
+++ b/libinotifytools/src/stats.h
@@ -1,6 +1,6 @@
 #ifndef STATS_H
 #define STATS_H
-#include "inotifytools.h"
+#include "inotifytools/inotifytools.h"
 #include "inotifytools/inotify.h"
 #include "inotifytools_p.h"
 


### PR DESCRIPTION
Fix for the error during compile of the `stats.c` - unable to find `inotifytools.h`. The header is in the `inotifytools` directory along with `inotify.h` In both the 3.21.9.0 and 3.21.9.5 releases.

`
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc -DHAVE_CONFIG_H -I. -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/build/inotify-tools-3.21.9.5/libinotifytools/src -I../.. -I../../libinotifytools/src/inotifytools -std=c99 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers -Werror -march=x86-64 -m64 -mmmx -msse -msse2 -mfpmath=sse -Wall -pipe -O2 -fomit-frame-pointer -Wno-error=misleading-indentation -MT stats.lo -MD -MP -MF .deps/stats.Tpo -c /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/build/inotify-tools-3.21.9.5/libinotifytools/src/stats.c -o stats.o
`

```
In file included from /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/build/inotify-tools-3.21.9.5/libinotifytools/src/inotifytools.c:18:
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-11.0-devel/build/inotify-tools-3.21.9.5/libinotifytools/src/stats.h:3:10: fatal error: inotifytools.h: No such file or directory
    3 | #include "inotifytools.h"
      |          ^~~~~~~~~~~~~~~~
```
