### PR TITLE
libinotifytools: Include limit.h for PATH_MAX

### DIFF
--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -17,6 +17,7 @@
 #include "inotifytools_p.h"
 #include "stats.h"
 
+#include <limits.h>
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>


### PR DESCRIPTION
musl builds fail since the required header which defines PATH_MAX is
missing, its perhaps included indirectly via glibc based systems

Signed-off-by: Khem Raj <raj.khem@gmail.com>