### PR TITLE
libinotifytools: Bridge differences between musl/glibc/kernel fnotify.h

### DIFF
--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -54,6 +54,12 @@ struct fanotify_event_fid {
 	struct fanotify_event_info_fid info;
 	struct file_handle handle;
 };
+
+#ifndef __GLIBC__
+#define val __val
+#define __kernel_fsid_t fsid_t
+#endif
+
 #endif
 
 /**


### PR DESCRIPTION
System detects to use sys/fnotify.h and then assumes glibc's definitions
but musl has definitions of its own. perhaps portable thing would be to
use linux/fnotify.h interface directly on linux irrespective of libc

See the differences discussion here [1]

[1] https://inbox.vuxu.org/musl/20191112220151.GC27331@x230/T/#ma8700992467200c8792e0fa8508eae656b81aeba

Signed-off-by: Khem Raj <raj.khem@gmail.com>