### PR TITLE
Properly terminate escaped CSV strings.

### DIFF
--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -73,6 +73,7 @@ static char* csv_escape_len(const char* string, size_t len) {
 	    !strchr(string, '\n') && string[0] != ' ' &&
 	    string[len - 1] != ' ') {
 		strncpy(csv, string, len);
+		csv[len] = '\0';
 		return csv;
 	}
 


### PR DESCRIPTION
strncpy() does not append a '\0' to the destination string. This results in the contents of a previous longer string showing at the end of a shorter string, or garbage if the buffer was not zeroed by the operating system.