### PR TITLE
libinotifytools: Rename init variable to fix conflict with entry point

### DIFF
--- a/libinotifytools/src/inotifytools.c
+++ b/libinotifytools/src/inotifytools.c
@@ -157,7 +157,7 @@ struct rbtree *tree_wd = 0;
 struct rbtree* tree_fid = 0;
 struct rbtree *tree_filename = 0;
 static int error = 0;
-int init = 0;
+int initialized = 0;
 int verbosity = 0;
 int fanotify_mode = 0;
 int fanotify_mark_type = 0;
@@ -299,7 +299,8 @@ watch *watch_from_filename( char const *filename ) {
  *         obtained from inotifytools_error().
  */
 int inotifytools_init(int fanotify, int watch_filesystem, int verbose) {
-	if (init) return 1;
+	if (initialized)
+		return 1;
 
 	error = 0;
 	verbosity = verbose;
@@ -323,7 +324,7 @@ int inotifytools_init(int fanotify, int watch_filesystem, int verbose) {
 	}
 
 	collect_stats = 0;
-	init = 1;
+	initialized = 1;
 	tree_wd = rbinit(wd_compare, 0);
 	tree_fid = rbinit(fid_compare, 0);
 	tree_filename = rbinit(filename_compare, 0);
@@ -366,9 +367,10 @@ void cleanup_tree(const void *nodep,
  * again before any other functions can be used.
  */
 void inotifytools_cleanup() {
-	if (!init) return;
+	if (!initialized)
+		return;
 
-	init = 0;
+	initialized = 0;
 	close(inotify_fd);
 	collect_stats = 0;
 	error = 0;
@@ -875,7 +877,7 @@ const char* inotifytools_filename_from_watch(watch* w) {
  *       filename returned will still be the original name.
  */
 const char* inotifytools_filename_from_wd(int wd) {
-	niceassert( init, "inotifytools_initialize not called yet" );
+	niceassert(initialized, "inotifytools_initialize not called yet");
 	if (!wd)
 		return "";
 	watch *w = watch_from_wd(wd);
@@ -980,7 +982,7 @@ char* inotifytools_dirpath_from_event(struct inotify_event* event) {
  *       establish the watch.
  */
 int inotifytools_wd_from_filename( char const * filename ) {
-	niceassert( init, "inotifytools_initialize not called yet" );
+	niceassert(initialized, "inotifytools_initialize not called yet");
 	if (!filename || !*filename)
 		return -1;
 	watch *w = watch_from_filename(filename);
@@ -1003,7 +1005,7 @@ int inotifytools_wd_from_filename( char const * filename ) {
  * @param filename New filename.
  */
 void inotifytools_set_filename_by_wd( int wd, char const * filename ) {
-	niceassert( init, "inotifytools_initialize not called yet" );
+	niceassert(initialized, "inotifytools_initialize not called yet");
 	watch *w = watch_from_wd(wd);
 	if (!w) return;
 	if (w->filename) free(w->filename);
@@ -1125,7 +1127,7 @@ watch* create_watch(int wd,
  *         obtained from inotifytools_error().
  */
 int inotifytools_remove_watch_by_wd( int wd ) {
-	niceassert( init, "inotifytools_initialize not called yet" );
+	niceassert(initialized, "inotifytools_initialize not called yet");
 	watch *w = watch_from_wd(wd);
 	if (!w) return 1;
 
@@ -1150,7 +1152,7 @@ int inotifytools_remove_watch_by_wd( int wd ) {
  *       establish the watch.
  */
 int inotifytools_remove_watch_by_filename( char const * filename ) {
-	niceassert( init, "inotifytools_initialize not called yet" );
+	niceassert(initialized, "inotifytools_initialize not called yet");
 	watch *w = watch_from_filename(filename);
 	if (!w) return 1;
 
@@ -1197,7 +1199,7 @@ int inotifytools_watch_file(char const* filename, int events) {
  *         obtained from inotifytools_error().
  */
 int inotifytools_watch_files(char const* filenames[], int events) {
-	niceassert( init, "inotifytools_initialize not called yet" );
+	niceassert(initialized, "inotifytools_initialize not called yet");
 	error = 0;
 
 	static int i;
@@ -1423,7 +1425,7 @@ struct inotify_event * inotifytools_next_event( long int timeout ) {
  *       the @a timeout period begins again each time a matching event occurs.
  */
 struct inotify_event * inotifytools_next_events( long int timeout, int num_events ) {
-	niceassert( init, "inotifytools_initialize not called yet" );
+	niceassert(initialized, "inotifytools_initialize not called yet");
 	niceassert( num_events <= MAX_EVENTS, "too many events requested" );
 
 	if ( num_events < 1 ) return NULL;
@@ -1718,7 +1720,7 @@ int inotifytools_watch_recursively(char const* path, int events) {
 int inotifytools_watch_recursively_with_exclude(char const* path,
 						int events,
 						char const** exclude_list) {
-	niceassert( init, "inotifytools_initialize not called yet" );
+	niceassert(initialized, "inotifytools_initialize not called yet");
 
 	DIR * dir;
 	char * my_path;

--- a/libinotifytools/src/inotifytools_p.h
+++ b/libinotifytools/src/inotifytools_p.h
@@ -45,7 +45,7 @@ void _niceassert( long cond, int line, char const * file,
                   char const * condstr, char const * mesg );
 
 struct rbtree *inotifytools_wd_sorted_by_event(int sort_event);
-extern int init;
+extern int initialized;
 
 struct fanotify_event_fid;
 

--- a/libinotifytools/src/stats.c
+++ b/libinotifytools/src/stats.c
@@ -250,7 +250,7 @@ int inotifytools_get_stat_by_filename( char const * filename,
  * event tallies to 0.
  */
 void inotifytools_initialize_stats() {
-	niceassert( init, "inotifytools_initialize not called yet" );
+	niceassert(initialized, "inotifytools_initialize not called yet");
 
 	// if already collecting stats, reset stats
 	if (collect_stats) {


### PR DESCRIPTION
Running inotifywait 3.22.1.0 on Ubuntu 22.04, I observed a bug apparently due to a bad file descriptor:

    $ inotifywait -e modify foo
    Setting up watches.
    Couldn't watch foo: Bad file descriptor

I could also reproduce with the master branch. Investigating further, it appears that `inotifytools_init()` in inotifytools.c exits immediately after entry, because the global variable `init` is non-null, even though we just called it at the beginning of inotifywait.c's `main()`, and the global variable is supposed to be initialised at `0`.

Bisecting showed that this variable used to be `static`, but was changed at some point to non-`static` to share it with stats.c, and this is where the bug first occurs. As far as I understand, the symbol conflicts with the `init()` function from [the program's entry point][0]. When entering `inotifytools_init()`, it seems that the value for that function is picked up and compared to `0`, found non-null, and the initialization function exits, leaving `inotify_fd` uninitialized (`-1`) and a bad file descriptor.

Renaming the variable to something other than `init` is enough to fix the bug.

    $ ./src/inotifywait -e modify foo
    Setting up watches.
    Watches established
    <waits>

[0]: https://www.geeksforgeeks.org/executing-main-in-c-behind-the-scene/

Fixes: dd59c5347af8 ("Extract stats into their own file (#129)")