### PR TITLE
Update Cirrus CI FreeBSD images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,8 +2,8 @@ task:
   name: FreeBSD
   freebsd_instance:
     matrix:
-      image_family: freebsd-13-1
-      image_family: freebsd-12-3
+      image_family: freebsd-13-2
+      image_family: freebsd-12-4
 
   pkginstall_script:
     - pkg install -y autoconf automake libtool bash git gcc


### PR DESCRIPTION
FreeBSD 13.2 and 12.4 are the currently supported releases