### PR TITLE
Fix fanotify_supported()

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -197,7 +197,7 @@ void warn_inotify_init_error(int fanotify) {
 	}
 }
 
-bool is_timeout_option_valid(unsigned int* timeout, char* o) {
+bool is_timeout_option_valid(long* timeout, char* o) {
 	if ((o == NULL) || (*o == '\0')) {
 		fprintf(stderr,
 			"The provided value is not a valid timeout value.\n"

--- a/src/common.h
+++ b/src/common.h
@@ -45,6 +45,6 @@ void construct_path_list(int argc,
 
 void warn_inotify_init_error(int fanotify);
 
-bool is_timeout_option_valid(unsigned int* timeout, char* o);
+bool is_timeout_option_valid(long* timeout, char* o);
 
 #endif

--- a/src/inotifywait.cpp
+++ b/src/inotifywait.cpp
@@ -36,7 +36,7 @@ static bool parse_opts(int* argc,
 		       int* events,
 		       bool* monitor,
 		       int* quiet,
-		       unsigned int* timeout,
+		       long* timeout,
 		       int* recursive,
 		       bool* csv,
 		       bool* daemon,
@@ -167,7 +167,7 @@ int main(int argc, char** argv) {
 	int orig_events;
 	bool monitor = false;
 	int quiet = 0;
-	unsigned int timeout = BLOCKING_TIMEOUT;
+	long timeout = BLOCKING_TIMEOUT;
 	int recursive = 0;
 	int fanotify = DEFAULT_FANOTIFY_MODE;
 	bool filesystem = false;
@@ -372,6 +372,11 @@ int main(int argc, char** argv) {
 	if (!quiet) {
 		output_error(sysl, "Watches established.\n");
 	}
+	if (timeout < 0) {
+		// Used to test filesystem support for inotify/fanotify
+		fprintf(stderr, "Negative timeout specified - abort!\n");
+		return EXIT_FAILURE;
+	}
 
 	// Now wait till we get event
 	struct inotify_event* event;
@@ -478,7 +483,7 @@ static bool parse_opts(int* argc,
 		       int* events,
 		       bool* monitor,
 		       int* quiet,
-		       unsigned int* timeout,
+		       long* timeout,
 		       int* recursive,
 		       bool* csv,
 		       bool* daemon,

--- a/src/inotifywatch.cpp
+++ b/src/inotifywatch.cpp
@@ -30,7 +30,7 @@ extern int optind, opterr, optopt;
 static bool parse_opts(int* argc,
 		       char*** argv,
 		       int* events,
-		       unsigned int* timeout,
+		       long* timeout,
 		       int* verbose,
 		       int* zero,
 		       int* sort,
@@ -81,7 +81,7 @@ int zero;
 
 int main(int argc, char** argv) {
 	events = 0;
-	unsigned int timeout = BLOCKING_TIMEOUT;
+	long timeout = BLOCKING_TIMEOUT;
 	int verbose = 0;
 	zero = 0;
 	int recursive = 0;
@@ -214,8 +214,13 @@ int main(int argc, char** argv) {
 	fprintf(stderr,
 		"Finished establishing watches, now collecting statistics.\n");
 
+	if (timeout < 0) {
+		// Used to test filesystem support for inotify/fanotify
+		fprintf(stderr, "Negative timeout specified - abort!\n");
+		return EXIT_FAILURE;
+	}
 	if (timeout && verbose) {
-		fprintf(stderr, "Will listen for events for %u seconds.\n",
+		fprintf(stderr, "Will listen for events for %lu seconds.\n",
 			timeout);
 	}
 
@@ -427,7 +432,7 @@ int print_info() {
 static bool parse_opts(int* argc,
 		       char*** argv,
 		       int* e,
-		       unsigned int* timeout,
+		       long* timeout,
 		       int* verbose,
 		       int* z,
 		       int* s,

--- a/t/fanotify-common.sh
+++ b/t/fanotify-common.sh
@@ -2,14 +2,7 @@
 
 # Check for kernel support and privileges
 fanotify_supported() {
-    if [ -z "$(grep 'kthreadd' /proc/2/status 2>/dev/null)" ]; then
-        # FIXME: fanotify does not work on overlayfs.
-        # https://stackoverflow.com/a/72136877/2995591
-        # https://github.com/inotify-tools/inotify-tools/pull/183
-        false
-    else
-        ../../src/fsnotifywait --fanotify $* 2>&1 | grep -q 'No files specified'
-    fi
+    ../../src/fsnotifywait --fanotify -t -1 $* "." 2>&1 | grep -q 'Negative timeout'
 }
 
 # Create and mount a test filesystem


### PR DESCRIPTION
Parse negative value of --timeout argument and error only after setting up all watches.

this is used to improve the helper to detect support for fanotify on a specific filesystem (e.g. overlayfs) and test permission for specific flags (e.g. --filesystem).

With this improvement, we can remove the workaround for not testing fanotify inside containers, because the helper will detect if kernel supports fanotify support inside containers or not (overlayfs support for fanotify should be supported in future kernels).