### PR TITLE
Return to building on 20.04 and 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,29 +3,6 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  # Some (fanotify) test cannot yet run containerized (*-multi):
-  # https://github.com/inotify-tools/inotify-tools/pull/183
-  ubuntu-latest:
-
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-    - uses: actions/checkout@v1
-    - name: build_and_test
-      run: ./build_and_test.sh clean
-
-  # It gets stuck forever with: Queued — Waiting to run this check...
-  #fedora-latest:
-  #
-  #  runs-on: fedora-latest
-  #  env:
-  #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #  steps:
-  #  - uses: actions/checkout@v1
-  #  - name: build_and_test
-  #    run: ./build_and_test.sh clean
-
   ubuntu-2004-multi:
 
     runs-on: ubuntu-20.04
@@ -36,13 +13,25 @@ jobs:
     - name: build_and_test_multi
       run: ./build_and_test_multi.sh clean
 
-  ubuntu-latest-multi:
+  ubuntu-2204-multi:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v1
     - name: build_and_test_multi
       run: ./build_and_test_multi.sh clean
+
+  # Some (fanotify) test cannot yet run containerized (*-multi):
+  # https://github.com/inotify-tools/inotify-tools/pull/183
+  ubuntu-22.04:
+
+    runs-on: ubuntu-22.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v1
+    - name: build_and_test
+      run: ./build_and_test.sh clean
 

--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -40,6 +40,7 @@ build() {
   ./configure --prefix=/usr $@
   make -j$j
   unset CFLAGS
+  unset CXXFLAGS
   unset LDFLAGS
 }
 
@@ -139,6 +140,7 @@ if [ "$os" != "freebsd" ] && ldconfig -p | grep -q libasan; then
   clean
   set_gcc
   export CFLAGS="-fsanitize=address -O0 -ggdb"
+  export CXXFLAGS="-fsanitize=address -O0 -ggdb"
   export LDFLAGS="-fsanitize=address -O0 -ggdb"
   build
   tests
@@ -236,6 +238,7 @@ if [ "$os" != "freebsd" ] && [ "$(uname -m)" = "x86_64" ]; then
   clean
   set_gcc
   unset CFLAGS
+  unset CXXFLAGS
   unset LDFLAGS
   ./autogen.sh
   ./configure


### PR DESCRIPTION
Building on latest can be unstable, back to manual bumps and availing
of newer OS's via containers. We will likely bump to 24.04 and
drop 20.04 when it's released. Some env var fixes also.