### PR TITLE
Ensure C++ libraries are not linked in

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,14 @@ AC_ARG_ENABLE(static-binary,
     STATIC_BINARY_ENABLE=$enableval, STATIC_BINARY_ENABLE=no)
 AM_CONDITIONAL([STATIC_BINARY_ENABLE], test "$STATIC_BINARY_ENABLE" = "yes")
 
+[
+if [ "$CC" = "clang" ] || [ "$CXX" = "clang++" ]; then
+  IS_CLANG="yes"
+else
+  IS_CLANG="no"
+fi
+]
+AM_CONDITIONAL(IS_CLANG, test "$IS_CLANG" = "yes")
 
 # Checks for libraries.
 

--- a/libinotifytools/src/Makefile.am
+++ b/libinotifytools/src/Makefile.am
@@ -3,6 +3,7 @@ SUBDIRS = inotifytools
 lib_LTLIBRARIES = libinotifytools.la
 libinotifytools_la_SOURCES = inotifytools.cpp inotifytools_p.h redblack.cpp redblack.h stats.cpp stats.h
 libinotifytools_la_CFLAGS = -I$(srcdir)/inotifytools
+libinotifytools_la_CXXFLAGS = -I$(srcdir)/inotifytools
 libinotifytools_la_LDFLAGS = -version-info 4:1:4
 
 check_PROGRAMS = test
@@ -16,7 +17,13 @@ EXTRA_DIST = example.cpp Doxyfile
 nobase_include_HEADERS = inotifytools/inotifytools.h inotifytools/inotify-nosys.h inotifytools/inotify.h
 nobase_include_HEADERS += inotifytools/fanotify-dfid-name.h inotifytools/fanotify.h
 
-AM_CFLAGS = -std=c99 -Wall -Wextra -Wshadow -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers -Werror
+if IS_CLANG
+AM_CFLAGS = -std=c99 -fno-exceptions -Wall -Wextra -Wshadow -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers -Werror -Wno-unused-command-line-argument
+AM_CXXFLAGS = -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers -Werror -Wno-unused-command-line-argument
+else
+AM_CFLAGS = -std=c99 -fno-exceptions -Wall -Wextra -Wshadow -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers -Werror
+AM_CXXFLAGS = -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers -Werror
+endif
 
 if DOXYGEN_ENABLE
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,8 +11,14 @@ fsnotifywatch_SOURCES = inotifywatch.cpp common.cpp common.h
 fsnotifywatch_CPPFLAGS = $(AM_CPPFLAGS) -DENABLE_FANOTIFY
 endif
 
-AM_CFLAGS = -Wall -Wextra -Wshadow -Werror -std=c99 -I../libinotifytools/src
-AM_CPPFLAGS = -I$(top_srcdir)/libinotifytools/src
+if IS_CLANG
+AM_CFLAGS = -std=c99 -fno-exceptions -Wall -Wextra -Wshadow -Werror -Wno-unused-command-line-argument -I../libinotifytools/src
+AM_CPPFLAGS = -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Werror -Wno-unused-command-line-argument -I../libinotifytools/src
+else
+AM_CFLAGS = -std=c99 -fno-exceptions -Wall -Wextra -Wshadow -Werror -I../libinotifytools/src
+AM_CPPFLAGS = -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Werror -I../libinotifytools/src
+endif
+
 LDADD = ../libinotifytools/src/libinotifytools.la
 
 if STATIC_BINARY_ENABLE

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -6,6 +6,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -71,8 +72,8 @@ FileList::~FileList() {
 }
 
 struct file {
-	FILE* file_ = nullptr;
-	bool is_stdin = false;
+	FILE* file_;
+	bool is_stdin;
 
 	FILE* open(const char* filename) {
 		file_ = fopen(filename, "r");
@@ -85,6 +86,8 @@ struct file {
 
 		return file_;
 	}
+
+	file() : file_(nullptr), is_stdin(false) {}
 
 	~file() {
 		if (file_)
@@ -110,8 +113,6 @@ void construct_path_list(int argc,
                 }
 	}
 
-	int watch_len = LIST_CHUNK;
-	int exclude_len = LIST_CHUNK;
 	int watch_count = 0;
 	int exclude_count = 0;
 	list->watch_files_ = (char const**)malloc(sizeof(char*) * LIST_CHUNK);


### PR DESCRIPTION
We will be doing a release soon and although we allow a subset of C++
we would like to avoid increasing our runtime dependency count, we
run on a lot of platforms.
