### PR TITLE
fix build when being done out of tree

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,11 +12,11 @@ fsnotifywatch_CPPFLAGS = $(AM_CPPFLAGS) -DENABLE_FANOTIFY
 endif
 
 if IS_CLANG
-AM_CFLAGS = -std=c99 -fno-exceptions -Wall -Wextra -Wshadow -Werror -Wno-unused-command-line-argument -I../libinotifytools/src
-AM_CPPFLAGS = -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Werror -Wno-unused-command-line-argument -I../libinotifytools/src
+AM_CFLAGS = -std=c99 -fno-exceptions -Wall -Wextra -Wshadow -Werror -Wno-unused-command-line-argument -I../libinotifytools/src -I$(srcdir)/../libinotifytools/src
+AM_CPPFLAGS = -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Werror -Wno-unused-command-line-argument -I../libinotifytools/src -I$(srcdir)/../libinotifytools/src
 else
-AM_CFLAGS = -std=c99 -fno-exceptions -Wall -Wextra -Wshadow -Werror -I../libinotifytools/src
-AM_CPPFLAGS = -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Werror -I../libinotifytools/src
+AM_CFLAGS = -std=c99 -fno-exceptions -Wall -Wextra -Wshadow -Werror -I../libinotifytools/src -I$(srcdir)/../libinotifytools/src
+AM_CPPFLAGS = -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Werror -I../libinotifytools/src -I$(srcdir)/../libinotifytools/src
 endif
 
 LDADD = ../libinotifytools/src/libinotifytools.la


### PR DESCRIPTION
When building "out of source tree" the src/yyy.cpp files can’t find inotifytools/inotifytools.h

```
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src -I.. -I../libinotifytools/src/inotifytools  -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Werror -I../libinotifytools/src -DENABLE_FANOTIFY   -march=x86-64-v3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -Wno-error=unused-parameter -MT fsnotifywait-inotifywait.o -MD -MP -MF .deps/fsnotifywait-inotifywait.Tpo -c -o fsnotifywait-inotifywait.o `test -f 'inotifywait.cpp' || echo '/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src/'`inotifywait.cpp
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src -I.. -I../libinotifytools/src/inotifytools  -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Werror -I../libinotifytools/src -DENABLE_FANOTIFY   -march=x86-64-v3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -Wno-error=unused-parameter -MT fsnotifywait-common.o -MD -MP -MF .deps/fsnotifywait-common.Tpo -c -o fsnotifywait-common.o `test -f 'common.cpp' || echo '/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src/'`common.cpp
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src -I.. -I../libinotifytools/src/inotifytools  -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Werror -I../libinotifytools/src -DENABLE_FANOTIFY   -march=x86-64-v3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -Wno-error=unused-parameter -MT fsnotifywatch-inotifywatch.o -MD -MP -MF .deps/fsnotifywatch-inotifywatch.Tpo -c -o fsnotifywatch-inotifywatch.o `test -f 'inotifywatch.cpp' || echo '/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src/'`inotifywatch.cpp
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-g++ -DHAVE_CONFIG_H -I. -I/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src -I.. -I../libinotifytools/src/inotifytools  -std=c++17 -fno-exceptions -Wall -Wextra -Wshadow -Werror -I../libinotifytools/src -DENABLE_FANOTIFY   -march=x86-64-v3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -Wno-error=unused-parameter -MT fsnotifywatch-common.o -MD -MP -MF .deps/fsnotifywatch-common.Tpo -c -o fsnotifywatch-common.o `test -f 'common.cpp' || echo '/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src/'`common.cpp
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src/common.cpp:15:10: fatal error: inotifytools/inotifytools.h: No such file or directory
   15 | #include <inotifytools/inotifytools.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:485: common.o] Error 1
make[2]: *** Waiting for unfinished jobs....
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src/inotifywatch.cpp:24:10: fatal error: inotifytools/inotifytools.h: No such file or directory
   24 | #include <inotifytools/inotifytools.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src/inotifywait.cpp:26:10: fatal error: inotifytools/inotifytools.h: No such file or directory
   26 | #include <inotifytools/inotifytools.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:485: inotifywatch.o] Error 1
make[2]: *** [Makefile:506: fsnotifywait-inotifywait.o] Error 1
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src/inotifywait.cpp:26:10: fatal error: inotifytools/inotifytools.h: No such file or directory
   26 | #include <inotifytools/inotifytools.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:485: inotifywait.o] Error 1
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src/common.cpp:15:10: fatal error: inotifytools/inotifytools.h: No such file or directory
   15 | #include <inotifytools/inotifytools.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src/common.cpp:15:10: fatal error: inotifytools/inotifytools.h: No such file or directory
   15 | #include <inotifytools/inotifytools.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:548: fsnotifywatch-common.o] Error 1
make[2]: *** [Makefile:520: fsnotifywait-common.o] Error 1
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/src/inotifywatch.cpp:24:10: fatal error: inotifytools/inotifytools.h: No such file or directory
   24 | #include <inotifytools/inotifytools.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:534: fsnotifywatch-inotifywatch.o] Error 1
make[2]: Leaving directory '/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/.x86_64-libreelec-linux-gnu/src'
make[1]: *** [Makefile:409: all-recursive] Error 1
make[1]: Leaving directory '/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-12.0-devel/build/inotify-tools-4.23.8.0/.x86_64-libreelec-linux-gnu'
make: *** [Makefile:341: all] Error 2
```

