### PR TITLE
Add flag for forcing static compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,11 @@ AC_ARG_ENABLE(static-binary,
     STATIC_BINARY_ENABLE=$enableval, STATIC_BINARY_ENABLE=no)
 AM_CONDITIONAL([STATIC_BINARY_ENABLE], test "$STATIC_BINARY_ENABLE" = "yes")
 
+AC_ARG_ENABLE(all-static,
+    AS_HELP_STRING([--enable-all-static],[force static linking of binaries]),
+    STATIC_BINARY_FORCE=$enableval, STATIC_BINARY_FORCE=no)
+AM_CONDITIONAL([STATIC_BINARY_FORCE], test "$STATIC_BINARY_FORCE" = "yes")
+
 [
 if [ "$CC" = "clang" ] || [ "$CXX" = "clang++" ]; then
   IS_CLANG="yes"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,10 @@ if STATIC_BINARY_ENABLE
 AM_LDFLAGS = -static-libtool-libs
 endif
 
+if STATIC_BINARY_FORCE
+AM_LDFLAGS = -all-static
+endif
+
 install-exec-hook:
 	cd $(DESTDIR)$(bindir) && \
 	$(LN_S) inotifywait fsnotifywait && \


### PR DESCRIPTION
This pull request introduces the --enable-all-static flag to force static compilation of the tools. Fixes #218 .

Usage example:
```bash
./autogen
./configure --prefix=/usr --host=aarch64-linux-gnu CXX=aarch64-linux-gnu-g++ --enable-all-static
make CXX=aarch64-linux-gnu-g++
```

As a sidenote, I'm not sure about the advantages for using  `-static-libtool-libs` over `-all-static`, so if I'm not missing anything, it's also possible to override the behavior of `--enable-static-binary` instead of introducing a new flag.
