### PR TITLE
Allow recursive watch with --include

### DIFF
--- a/libinotifytools/src/inotifytools/inotifytools.h
+++ b/libinotifytools/src/inotifytools/inotifytools.h
@@ -51,8 +51,8 @@ int inotifytools_watch_recursively_with_exclude(char const* path,
 						int events,
 						char const** exclude_list);
 // [UH]
-int inotifytools_ignore_events_by_regex( char const *pattern, int flags );
-int inotifytools_ignore_events_by_inverted_regex( char const *pattern, int flags );
+int inotifytools_ignore_events_by_regex( char const *pattern, int flags, int recursive );
+int inotifytools_ignore_events_by_inverted_regex( char const *pattern, int flags, int recursive );
 struct inotify_event * inotifytools_next_event( long int timeout );
 struct inotify_event * inotifytools_next_events( long int timeout, int num_events );
 int inotifytools_error();

--- a/man/inotifywait.1.in
+++ b/man/inotifywait.1.in
@@ -153,6 +153,9 @@ specified POSIX regular expression, case insensitive.
 .B \-\-include <pattern>
 Process events only for the subset of files whose filenames match the specified
 POSIX regular expression, case sensitive.
+When used with \-\-recursive, events will still be generated for matching files
+inside newly created directories, even if the directory names themselves do not
+match the pattern.
 
 .TP
 .B \-\-includei <pattern>

--- a/src/inotifywatch.cpp
+++ b/src/inotifywatch.cpp
@@ -115,17 +115,17 @@ int main(int argc, char** argv) {
 	}
 
 	if ((exc_regex &&
-	     !inotifytools_ignore_events_by_regex(exc_regex, REG_EXTENDED)) ||
+	     !inotifytools_ignore_events_by_regex(exc_regex, REG_EXTENDED, recursive)) ||
 	    (exc_iregex && !inotifytools_ignore_events_by_regex(
-			       exc_iregex, REG_EXTENDED | REG_ICASE))) {
+			       exc_iregex, REG_EXTENDED | REG_ICASE, recursive))) {
 		fprintf(stderr, "Error in `exclude' regular expression.\n");
 		return EXIT_FAILURE;
 	}
 
 	if ((inc_regex && !inotifytools_ignore_events_by_inverted_regex(
-			      inc_regex, REG_EXTENDED)) ||
+			      inc_regex, REG_EXTENDED, recursive)) ||
 	    (inc_iregex && !inotifytools_ignore_events_by_inverted_regex(
-			       inc_iregex, REG_EXTENDED | REG_ICASE))) {
+			       inc_iregex, REG_EXTENDED | REG_ICASE, recursive))) {
 		fprintf(stderr, "Error in `include' regular expression.\n");
 		return EXIT_FAILURE;
 	}

--- a/t/inotifywait-recursive-include.t
+++ b/t/inotifywait-recursive-include.t
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+test_description='Recursive watch with include filter
+
+Verify that:
+1. Only files matching include pattern are shown in events
+2. Directory events are not shown but directories are still watched
+3. Files matching pattern in subdirectories trigger events
+'
+
+. ./sharness.sh
+
+logfile="log"
+
+run_() {
+    export LD_LIBRARY_PATH="../../libinotifytools/src/"
+    testdir=root/A/B
+    
+    rm -rf root && mkdir -p $testdir || return 1
+
+    # Start inotifywait in monitor mode
+    ../../src/inotifywait \
+        --quiet \
+        --monitor \
+        --recursive \
+        --outfile $logfile \
+        --include "\.txt$" \
+        --event CREATE \
+        --format "%w%f" \
+        root &
+    
+    inotifywait_pid=$!
+
+    # Wait for watches to be established
+    sleep 1
+
+    # Create test files
+    touch $testdir/test.dat
+    touch $testdir/test.txt
+    mkdir $testdir/subdir
+    touch $testdir/subdir/nested.txt
+    touch $testdir/subdir/nested.dat
+
+    # Give inotifywait time to process events
+    sleep 1
+
+    # Kill inotifywait
+    kill $inotifywait_pid
+    wait $inotifywait_pid || true
+}
+
+test_expect_success 'correct events logged for recursive watch with include filter' '
+    rm -f $logfile &&
+    run_ &&
+    test -f $logfile &&
+    test $(grep -c "test.txt\|nested.txt" $logfile) = 2 &&
+    grep "root/A/B/test.txt" $logfile &&
+    grep "root/A/B/subdir/nested.txt" $logfile &&
+    ! grep "test.dat" $logfile &&
+    ! grep "nested.dat" $logfile &&
+    ! grep "subdir$" $logfile
+'
+
+test_done

--- a/t/inotifywait-recursive-multiple-includes.t
+++ b/t/inotifywait-recursive-multiple-includes.t
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+test_description='Recursive watch with multiple include filters
+
+Verify that:
+1. Files matching any include pattern trigger events
+2. Files not matching any pattern are ignored
+3. Directory events are not shown but directories are still watched
+'
+
+. ./sharness.sh
+
+logfile="log"
+
+run_() {
+    export LD_LIBRARY_PATH="../../libinotifytools/src/"
+    testdir=root/A/B
+    
+    rm -rf root && mkdir -p $testdir || return 1
+
+    # Start inotifywait in monitor mode
+    ../../src/inotifywait \
+        --quiet \
+        --monitor \
+        --recursive \
+        --outfile $logfile \
+        --include ".*\.(txt|log)$" \
+        --event CREATE \
+        --format "%w%f" \
+        root &
+    
+    inotifywait_pid=$!
+
+    # Wait for watches to be established
+    sleep 1
+
+    # Create test files
+    touch $testdir/test.dat
+    touch $testdir/test.txt
+    touch $testdir/info.log
+    mkdir $testdir/subdir
+    touch $testdir/subdir/nested.txt
+    touch $testdir/subdir/data.log
+    touch $testdir/subdir/other.dat
+
+    # Give inotifywait time to process events
+    sleep 1
+
+    # Kill inotifywait
+    kill $inotifywait_pid
+    wait $inotifywait_pid || true
+}
+
+test_expect_success 'correct events logged for multiple include filters' '
+    rm -f $logfile &&
+    run_ &&
+    test -f $logfile &&
+    test $(grep -c "txt\|log" $logfile) = 4 &&
+    grep "root/A/B/test.txt" $logfile &&
+    grep "root/A/B/info.log" $logfile &&
+    grep "root/A/B/subdir/nested.txt" $logfile &&
+    grep "root/A/B/subdir/data.log" $logfile &&
+    ! grep "test.dat" $logfile &&
+    ! grep "other.dat" $logfile &&
+    ! grep "subdir$" $logfile
+'
+
+test_done 


### PR DESCRIPTION
This addition changes the functionality of the --recursive flag when it's used with --include.

Prior to the change, when watching a folder recursively, watches are not added for newly created subdirectorires unless they match the filter.

With this change, folders are not matched against the filter when deciding to monitor them recursively.

Scenario:
1. Create a folder /tmp/x
2. Run inotifywait -r -i "txt$" /tmp/x
3. Create a file /tmp/x/test.txt   -> inotifywait notices the creation
4. Create a file /tmp/x/test -> inotifywait does not notice it (because it does not match include filter)
5. Create a folder /tmp/x/y.txt/ -> inotify notices the creation and monitors recursively
6. Create a file /tmp/x/y.txt/test -> inotify notices the creation (because it's monitoring /tmp/x.txt/ recursively

Prior to the changes:
7. Create a folder /tmp/x/z/ -> inotify does not notice this or set recursive watch (because it does not match the filter)
8. Create a file /tmp/x/z/test.txt -> inotify does not notice, since it's not recursively watching.

With the changes:
7. Create a folder /tmp/x/z/ -> inotify sets a recursive watch on this folder, even if it does not match the filter
8. Create a file /tmp/x/z/test.txt -> inotify notices this file because it's watching recursively and it matches the filter

There are multiple mentions of this or similar issues in the Issues list, and I hit the same issue when starting to use inotifywait:
https://github.com/inotify-tools/inotify-tools/issues/224
https://github.com/inotify-tools/inotify-tools/issues/199
https://github.com/inotify-tools/inotify-tools/issues/168



