### PR TITLE
Fix a crash on >=1024 watched files

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -113,13 +113,15 @@ void construct_path_list(int argc,
                 }
 	}
 
-	int watch_count = 0;
-	int exclude_count = 0;
-	list->watch_files_ = (char const**)malloc(sizeof(char*) * LIST_CHUNK);
+	size_t watch_count = 0;
+	size_t watch_allocated = LIST_CHUNK;
+	size_t exclude_count = 0;
+	size_t exclude_allocated = LIST_CHUNK;
+	list->watch_files_ = (char const**)malloc(sizeof(char*) * watch_allocated);
 	if (!list->watch_files_)
 		return;
 
-	list->exclude_files_ = (char const**)malloc(sizeof(char*) * LIST_CHUNK);
+	list->exclude_files_ = (char const**)malloc(sizeof(char*) * exclude_allocated);
 	if (!list->exclude_files_)
 		return;
 
@@ -133,11 +135,31 @@ void construct_path_list(int argc,
 			continue;
 
 		if ('@' == name[0]) {
+			if (exclude_count == exclude_allocated - 1) {
+				exclude_allocated *= 2;
+				auto mem = (char const**) realloc (list->exclude_files_, sizeof(char*) * exclude_allocated);
+				if (!mem) {
+					list->watch_files_[watch_count] = NULL;
+					list->exclude_files_[exclude_count] = NULL;
+					return;
+				}
+				list->exclude_files_ = mem;
+			}
 			list->exclude_files_[exclude_count++] =
 			    strdup(&name[1]);
 			continue;
 		}
 
+		if (watch_count == watch_allocated - 1) {
+			watch_allocated *= 2;
+			auto mem = (char const**) realloc (list->watch_files_, sizeof(char*) * watch_allocated);
+			if (!mem) {
+				list->watch_files_[watch_count] = NULL;
+				list->exclude_files_[exclude_count] = NULL;
+				return;
+			}
+			list->watch_files_ = mem;
+		}
 		list->watch_files_[watch_count++] = strdup(name);
 	}
 
@@ -147,11 +169,31 @@ void construct_path_list(int argc,
 			continue;
 
 		if ('@' == argv[i][0]) {
+			if (exclude_count == exclude_allocated - 1) {
+				exclude_allocated *= 2;
+				auto mem = (char const**) realloc (list->exclude_files_, sizeof(char*) * exclude_allocated);
+				if (!mem) {
+					list->watch_files_[watch_count] = NULL;
+					list->exclude_files_[exclude_count] = NULL;
+					return;
+				}
+				list->exclude_files_ = mem;
+			}
 			list->exclude_files_[exclude_count++] =
 			    strdup(&argv[i][1]);
 			continue;
 		}
 
+		if (watch_count == watch_allocated - 1) {
+			watch_allocated *= 2;
+			auto mem = (char const**) realloc (list->watch_files_, sizeof(char*) * watch_allocated);
+			if (!mem) {
+				list->watch_files_[watch_count] = NULL;
+				list->exclude_files_[exclude_count] = NULL;
+				return;
+			}
+			list->watch_files_ = mem;
+		}
 		list->watch_files_[watch_count++] = strdup(argv[i]);
 	}
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2345921
Bugreported by Don Marti.
```
$ find . -xdev -type f -print0 | xargs -0 ./src/inotifywait
Setting up watches.
Couldn't watch ���*: No such file or directory
double free or corruption (out)
xargs: ./src/inotifywait: terminated by signal 6
$ make CFLAGS="-fsanitize=address -g" CXXFLAGS="-fsanitize=address -g" LDFLAGS=-fsanitize=address
$ find . -xdev -type f -print0 | xargs -0 /tmp/inotify-tools/src/inotifywait
=================================================================
==3349755==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x525000002100 at pc 0x000000406db9 bp 0x7fffff8e2570 sp 0x7fffff8e2568
WRITE of size 8 at 0x525000002100 thread T0
    #0 0x406db8 in construct_path_list(int, char**, char const*, FileList*) /tmp/inotify-tools/src/common.cpp:155
    #1 0x402e1b in main /tmp/inotify-tools/src/inotifywait.cpp:246
    #2 0x7feb9e210247 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #3 0x7feb9e21030a in __libc_start_main_impl ../csu/libc-start.c:360
    #4 0x4014d4 in _start (/tmp/inotify-tools/src/.libs/inotifywait+0x4014d4) (BuildId: da34ddfd0d04acad36a0af07acae3144311e1b7d)

0x525000002100 is located 0 bytes after 8192-byte region [0x525000000100,0x525000002100)
allocated by thread T0 here:
    #0 0x7feb9e8c2897 in malloc (/lib64/libasan.so.8+0xc2897) (BuildId: 0505b45e5a5d9a6c8ecb1d529aaaf13cd21fbe4e)
    #1 0x40678f in construct_path_list(int, char**, char const*, FileList*) /tmp/inotify-tools/src/common.cpp:118
    #2 0x402e1b in main /tmp/inotify-tools/src/inotifywait.cpp:246
    #3 0x7feb9e210247 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #4 0x7feb9e21030a in __libc_start_main_impl ../csu/libc-start.c:360
    #5 0x4014d4 in _start (/tmp/inotify-tools/src/.libs/inotifywait+0x4014d4) (BuildId: da34ddfd0d04acad36a0af07acae3144311e1b7d)
```
The patch is very ugly but I did not want to spend time to rewrite it all into real C++ smart memory allocators.
