### PR TITLE
Fanotify mount watch

### DIFF
--- a/libinotifytools/src/inotifytools.cpp
+++ b/libinotifytools/src/inotifytools.cpp
@@ -354,7 +354,7 @@ watch* watch_from_filename(char const* filename) {
  * @return 1 on success, 0 on failure.  On failure, the error can be
  *         obtained from inotifytools_error().
  */
-int inotifytools_init(int fanotify, int watch_filesystem, int verbose) {
+int inotifytools_init(int fanotify, char watch_scope, int verbose) {
 	if (initialized)
 		return 1;
 
@@ -366,9 +366,10 @@ int inotifytools_init(int fanotify, int watch_filesystem, int verbose) {
 		self_pid = getpid();
 		fanotify_mode = 1;
 		fanotify_mark_type =
-		    watch_filesystem ? FAN_MARK_FILESYSTEM : FAN_MARK_INODE;
+		    watch_scope == 'M' ? FAN_MARK_MOUNT :
+		    watch_scope ? FAN_MARK_FILESYSTEM : FAN_MARK_INODE;
 		at_handle_fid =
-		    watch_filesystem ? 0 : AT_HANDLE_FID;
+		    watch_scope ? 0 : AT_HANDLE_FID;
 		inotify_fd =
 		    fanotify_init(FAN_REPORT_FID | FAN_REPORT_DFID_NAME, 0);
 #endif

--- a/libinotifytools/src/inotifytools/inotifytools.h
+++ b/libinotifytools/src/inotifytools/inotifytools.h
@@ -62,7 +62,7 @@ int inotifytools_get_stat_by_filename( char const * filename,
                                                 int event );
 void inotifytools_initialize_stats();
 int inotifytools_initialize();
-int inotifytools_init(int fanotify, int watch_filesystem, int verbose);
+int inotifytools_init(int fanotify, char watch_scope, int verbose);
 void inotifytools_cleanup();
 int inotifytools_get_num_watches();
 

--- a/libinotifytools/src/inotifytools_p.h
+++ b/libinotifytools/src/inotifytools_p.h
@@ -52,7 +52,7 @@ extern int initialized;
 
 struct fanotify_event_fid;
 
-#define MAX_FID_LEN 20
+#define MAX_FID_LEN 64
 
 typedef struct watch {
 	struct fanotify_event_fid* fid;

--- a/man/inotifywait.1.in
+++ b/man/inotifywait.1.in
@@ -5,7 +5,7 @@ inotifywait, fsnotifywait \- wait for changes to files using inotify or fanotify
 
 .SH SYNOPSIS
 .B inotifywait
-.RB [ \-hcmrPqIFS ]
+.RB [ \-hcmrPqIFMS ]
 .RB [ \-e
 <event> ]
 .RB [ \-t
@@ -247,6 +247,10 @@ As of kernel v5.12, fanotify requires admin privileges.
 .TP
 .B \-S, \-\-filesystem
 Watch entire filesystem of any directories passed as arguments using fanotify.
+
+.TP
+.B \-M, \-\-mount
+Watch entire mount of any directories passed as arguments using fanotify.
 
 
 

--- a/t/fanotify-common.sh
+++ b/t/fanotify-common.sh
@@ -2,7 +2,7 @@
 
 # Check for kernel support and privileges
 fanotify_supported() {
-    ../../src/fsnotifywait --fanotify -t -1 $* "." 2>&1 | grep -q 'Negative timeout'
+    ../../src/inotifywait --fanotify -t -1 $* "." 2>&1 | grep -q 'Negative timeout'
 }
 
 # Create and mount a test filesystem

--- a/t/fanotify-common.sh
+++ b/t/fanotify-common.sh
@@ -2,7 +2,10 @@
 
 # Check for kernel support and privileges
 fanotify_supported() {
-    ../../src/inotifywait --fanotify -t -1 $* "." 2>&1 | grep -q 'Negative timeout'
+    output=$(../../src/inotifywait --fanotify -t -1 $* "." 2>&1)
+    # Success cases: "Negative timeout" (fanotify watch works)
+    #                "Operation not permitted" (fanotify supported but no perms)
+    echo "$output" | grep -q -E 'Negative timeout|Operation not permitted'
 }
 
 # Create and mount a test filesystem

--- a/t/fanotify-common.sh
+++ b/t/fanotify-common.sh
@@ -15,3 +15,61 @@ mount_filesystem() {
         mkdir -p $mnt && mount -o loop img $mnt && \
         df -t $fstype $mnt
 }
+
+# Create tmpfs mount
+mount_tmpfs() {
+    mnt=$1
+    size=${2:-10M}
+    mkdir -p $mnt && mount -t tmpfs -o size=$size tmpfs $mnt
+}
+
+# Create and mount a btrfs filesystem with subvolumes
+mount_btrfs_with_subvolumes() {
+    size=$1
+    mnt=$2
+    subvol_name=${3:-subvol1}
+
+    rm -f btrfs.img
+    truncate -s $size btrfs.img && mkfs.btrfs btrfs.img && \
+        mkdir -p $mnt && mount -o loop btrfs.img $mnt && \
+        btrfs subvolume create $mnt/$subvol_name && \
+        df -t btrfs $mnt
+}
+
+# Create an overlayfs mount
+mount_overlayfs() {
+    base_dir=$1
+    work_dir=${base_dir}_work
+    upper_dir=${base_dir}_upper
+    overlay_dir=${base_dir}_overlay
+
+    mkdir -p $base_dir $work_dir $upper_dir $overlay_dir && \
+        mount -t overlay overlay \
+        -o lowerdir=$base_dir,upperdir=$upper_dir,workdir=$work_dir \
+        $overlay_dir
+}
+
+# Test if we're running as root
+is_root() {
+    [ $(id -u) -eq 0 ]
+}
+
+# Test if we can create btrfs filesystems
+btrfs_supported() {
+    which mkfs.btrfs >/dev/null 2>&1
+}
+
+# Test if overlayfs is supported
+overlayfs_supported() {
+    grep -q overlay /proc/filesystems 2>/dev/null
+}
+
+# Clean up filesystem mounts
+cleanup_mounts() {
+    for mnt in "$@"; do
+        if mountpoint -q "$mnt" 2>/dev/null; then
+            umount -l "$mnt" 2>/dev/null || true
+        fi
+        rm -rf "$mnt" 2>/dev/null || true
+    done
+}

--- a/t/fsnotifywait-errors.t
+++ b/t/fsnotifywait-errors.t
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+test_description='Error handling and edge cases
+
+Verify that inotifywait handles error conditions gracefully
+for --mount and --filesystem options
+'
+
+. ./fanotify-common.sh
+. ./sharness.sh
+
+# Test privilege requirements
+if ! is_root; then
+    test_expect_success 'filesystem watch requires appropriate privileges' '
+        ../../src/inotifywait --filesystem --timeout 1 / 2>error.log
+        status=$?
+        test $status -ne 0 &&
+        grep -q "Operation not permitted" error.log
+    '
+
+    test_expect_success 'mount watch requires appropriate privileges' '
+        ../../src/inotifywait --mount --timeout 1 / 2>error.log
+        status=$?
+        test $status -ne 0 &&
+        grep -q "Operation not permitted" error.log
+    '
+fi
+
+# Test invalid paths
+test_expect_success 'filesystem watch handles non-existent paths' '
+    ! ../../src/inotifywait \
+        --filesystem \
+        --timeout 1 \
+        /definitely/does/not/exist 2>error.log
+'
+
+test_expect_success 'mount watch handles non-existent paths' '
+    ! ../../src/inotifywait \
+        --mount \
+        --timeout 1 \
+        /definitely/does/not/exist 2>error.log
+'
+
+# Test that --mount and --filesystem automatically enable fanotify
+test_expect_success 'mount option automatically enables fanotify' '
+    ../../src/inotifywait \
+        --mount \
+        --timeout 1 \
+        . 2>error.log || true &&
+    ! grep -i "inotify" error.log
+'
+
+test_expect_success 'filesystem option automatically enables fanotify' '
+    ../../src/inotifywait \
+        --filesystem \
+        --timeout 1 \
+        . 2>error.log || true &&
+    ! grep -i "inotify" error.log
+'
+
+# Test incompatible option combinations
+test_expect_success 'mount and filesystem options are mutually exclusive' '
+    ! ../../src/inotifywait \
+        --mount \
+        --filesystem \
+        --timeout 1 \
+        . 2>error.log
+'
+
+test_expect_success 'inotify and filesystem options are mutually exclusive' '
+    ! ../../src/inotifywait \
+        --inotify \
+        --filesystem \
+        --timeout 1 \
+        . 2>error.log
+'
+
+test_expect_success 'inotify and mount options are mutually exclusive' '
+    ! ../../src/inotifywait \
+        --inotify \
+        --mount \
+        --timeout 1 \
+        . 2>error.log
+'
+
+test_done

--- a/t/fsnotifywait-filesystems.t
+++ b/t/fsnotifywait-filesystems.t
@@ -1,0 +1,166 @@
+#!/bin/sh
+
+test_description='Filesystem-specific watch tests
+
+Verify that inotifywait --fanotify works correctly
+with different filesystem types including btrfs subvolumes and overlayfs
+'
+
+. ./fanotify-common.sh
+. ./sharness.sh
+
+logfile="log"
+
+# Check if we can run filesystem tests
+if ! is_root; then
+    skip_all="filesystem tests require root privileges"
+    test_done
+fi
+
+run_() {
+    export LD_LIBRARY_PATH="../../libinotifytools/src/"
+    testdir=$1/A/B/C/D
+    mnt=$1
+    rm -rf $mnt/A &&
+        mkdir -p $testdir &&
+	{(sleep 1 && touch $testdir/test)&} &&
+    ../../src/inotifywait \
+        --filesystem \
+        --quiet \
+        --outfile $logfile \
+        --event CREATE \
+        --timeout 3 \
+        $mnt
+}
+
+run_and_check_log()
+{
+    rm -f $logfile
+    run_ $1 && grep 'CREATE.*test$' $logfile
+}
+
+# Test btrfs filesystem support
+if fanotify_supported --filesystem && is_root && btrfs_supported; then
+    test_expect_success 'filesystem watch works with btrfs' '
+        test_when_finished "cleanup_mounts btrfs_root" &&
+        mount_filesystem btrfs 120M btrfs_root &&
+        run_and_check_log btrfs_root
+    '
+
+    test_expect_success 'filesystem watch detects changes in btrfs subvolumes' '
+        test_when_finished "cleanup_mounts btrfs_root" &&
+        mount_btrfs_with_subvolumes 120M btrfs_root subvol1 &&
+        # Test events in the subvolume
+        {
+            mkdir -p btrfs_root/subvol1/testdir &&
+            {(sleep 1 && touch btrfs_root/subvol1/testdir/subvol_file)&} &&
+            ../../src/inotifywait \
+                --filesystem \
+                --quiet \
+                --outfile $logfile \
+                --event CREATE \
+                --timeout 3 \
+                btrfs_root &&
+            grep -q "CREATE.*subvol_file" $logfile
+        }
+    '
+
+    # Check if btrfs subvolumes support fanotify directory watches (since v6.8)
+    mount_btrfs_with_subvolumes 120M btrfs_check subvol1 >/dev/null || {
+        cleanup_mounts btrfs_check
+        test_skip_btrfs_fanotify="Btrfs subvolume mount failed"
+    }
+
+    if test -z "$test_skip_btrfs_fanotify"; then
+        mkdir -p btrfs_check/subvol1/testdir &&
+        ../../src/inotifywait --fanotify --timeout -1 btrfs_check/subvol1/testdir 2>error.log || {
+            if grep -q "Invalid cross-device link" error.log; then
+                test_skip_btrfs_fanotify="Btrfs subvolume fanotify watches not supported"
+            fi
+        }
+        cleanup_mounts btrfs_check
+    fi
+
+    if test -z "$test_skip_btrfs_fanotify"; then
+        test_expect_success 'fanotify directory watch works inside btrfs subvolumes' '
+            test_when_finished "cleanup_mounts btrfs_root" &&
+            mount_btrfs_with_subvolumes 120M btrfs_root subvol1 &&
+            # Test events in the subvolume
+            {
+                mkdir -p btrfs_root/subvol1/testdir &&
+                {(sleep 1 && touch btrfs_root/subvol1/testdir/subvol_file)&} &&
+                ../../src/inotifywait \
+                    --fanotify \
+                    --quiet \
+                    --outfile $logfile \
+                    --event CREATE \
+                    --timeout 3 \
+                    btrfs_root/subvol1/testdir &&
+                grep -q "CREATE.*subvol_file" $logfile
+            }
+        '
+    else
+        echo "# SKIP: $test_skip_btrfs_fanotify"
+    fi
+fi
+
+# Test overlayfs support
+if fanotify_supported && overlayfs_supported; then
+    # Check if overlayfs supports fanotify directory watches (since v6.6)
+    mkdir -p overlay_test_check
+    mount_overlayfs overlay_test_check 2>/dev/null || {
+        cleanup_mounts overlay_test_check overlay_test_check_overlay
+        test_skip_overlayfs="Overlayfs mount failed"
+    }
+
+    if test -z "$test_skip_overlayfs"; then
+        ../../src/inotifywait --fanotify --timeout -1 overlay_test_check_overlay 2>error.log || {
+            if grep -q "Operation not supported" error.log; then
+                test_skip_overlayfs="Overlayfs does not support fanotify watches"
+            fi
+        }
+        cleanup_mounts overlay_test_check overlay_test_check_overlay
+    fi
+
+    if test -z "$test_skip_overlayfs"; then
+        test_expect_success 'fanotify directory watch works with overlayfs' '
+            test_when_finished "cleanup_mounts overlay_test overlay_test_overlay" &&
+            mkdir -p overlay_test &&
+            mount_overlayfs overlay_test &&
+            {
+                mkdir -p overlay_test_overlay/testdir &&
+                {(sleep 1 && touch overlay_test_overlay/testdir/overlay_file)&} &&
+                ../../src/inotifywait \
+                    --fanotify \
+                    --quiet \
+                    --outfile $logfile \
+                    --event CREATE \
+                    --timeout 3 \
+                    overlay_test_overlay/testdir &&
+                grep -q "CREATE.*overlay_file" $logfile
+            }
+        '
+    else
+        echo "# SKIP: $test_skip_overlayfs"
+    fi
+fi
+
+# Test ext4 filesystem with extended attributes
+if fanotify_supported --filesystem && is_root; then
+    test_expect_success 'filesystem watch works with ext4' '
+        test_when_finished "cleanup_mounts ext4_root" &&
+        mount_filesystem ext4 50M ext4_root &&
+        run_and_check_log ext4_root
+    '
+fi
+
+# Test tmpfs (useful baseline)
+if fanotify_supported --filesystem && is_root; then
+    test_expect_success 'filesystem watch works with tmpfs' '
+        test_when_finished "cleanup_mounts tmpfs_root" &&
+        mount_tmpfs tmpfs_root 10M &&
+        run_and_check_log tmpfs_root
+    '
+fi
+
+test_done

--- a/t/fsnotifywait-mount.t
+++ b/t/fsnotifywait-mount.t
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+test_description='Mount watch
+
+Verify that inotifywait --mount gets events on
+files within the mounted filesystem
+'
+
+. ./fanotify-common.sh
+. ./sharness.sh
+
+logfile="log"
+
+run_() {
+    export LD_LIBRARY_PATH="../../libinotifytools/src/"
+    testdir=root/A/B/C/D
+    rm -rf root/A &&
+        mkdir -p $testdir &&
+	{(sleep 1 && touch $testdir/test && cat $testdir/test)&} &&
+    ../../src/$* \
+        --quiet \
+        --outfile $logfile \
+        --timeout 3 \
+        root
+}
+
+run_and_check_log()
+{
+    rm -f $logfile
+    pattern="$1"
+    shift
+    run_ $* && grep "$pattern" $logfile
+}
+
+# Check if we can run mount tests
+if ! is_root; then
+    skip_all="mount tests require root privileges"
+    test_done
+fi
+
+# Test --mount with supported events (OPEN, CLOSE)
+if fanotify_supported --mount && is_root; then
+    test_expect_success 'mount watch logs OPEN events' '
+        test_when_finished "cleanup_mounts root" &&
+        mount_filesystem ext2 10M root &&
+        run_and_check_log "OPEN" inotifywait --mount
+    '
+
+    test_expect_success 'mount watch logs CLOSE events' '
+        test_when_finished "cleanup_mounts root" &&
+        mount_filesystem ext2 10M root &&
+        run_and_check_log "CLOSE" inotifywait --mount --event CLOSE_NOWRITE
+    '
+
+    # Test that --mount works with different filesystem types
+    test_expect_success 'mount watch works with tmpfs' '
+        test_when_finished "cleanup_mounts root" &&
+        mount_tmpfs root &&
+        run_and_check_log "OPEN" inotifywait --mount
+    '
+
+    # Test error conditions - events not supported by mount marks
+    test_expect_success 'mount watch may not support CREATE events' '
+        test_when_finished "cleanup_mounts root" &&
+        mount_filesystem ext2 10M root &&
+        {
+            # CREATE events may or may not work with mount marks
+            # depending on kernel version, so we just verify the tool runs
+            run_ inotifywait --mount --event CREATE --timeout 1 || true
+        }
+    '
+
+fi
+
+test_done

--- a/t/fsnotifywait-subtree.t
+++ b/t/fsnotifywait-subtree.t
@@ -2,7 +2,7 @@
 
 test_description='Subtree watch
 
-Verify that fsnotifywait --recursive/--filesystem gets events on
+Verify that inotifywait --recursive/--filesystem gets events on
 files created inside the watched subtree
 '
 
@@ -37,7 +37,7 @@ test_expect_success 'event logged' '
 
 if fanotify_supported; then
     test_expect_success 'event logged' '
-        run_and_check_log fsnotifywait --fanotify --recursive
+        run_and_check_log inotifywait --fanotify --recursive
     '
 fi
 
@@ -47,7 +47,7 @@ if fanotify_supported --filesystem && [ $(id -u) -eq 0 ]; then
     test_expect_success 'event logged' '
         test_when_finished "umount -l root" &&
         mount_filesystem ext2 10M root &&
-        run_and_check_log fsnotifywait --filesystem
+        run_and_check_log inotifywait --filesystem
     '
 fi
 

--- a/t/fsnotifywait-subtree.t
+++ b/t/fsnotifywait-subtree.t
@@ -10,19 +10,20 @@ files created inside the watched subtree
 . ./sharness.sh
 
 logfile="log"
+subdir="root/A"
+extdir="root/X"
 
 run_() {
     export LD_LIBRARY_PATH="../../libinotifytools/src/"
     testdir=root/A/B/C/D
-    rm -rf root/A &&
         mkdir -p $testdir &&
-	{(sleep 1 && touch $testdir/test)&} &&
+	{(sleep 1 && touch $extdir/ignore $testdir/test 2>/dev/null)&} &&
     ../../src/$* \
         --quiet \
         --outfile $logfile \
         --event CREATE \
         --timeout 2 \
-        root
+        $subdir
 }
 
 run_and_check_log()
@@ -32,21 +33,35 @@ run_and_check_log()
 }
 
 test_expect_success 'event logged' '
+    rm -rf root &&
     run_and_check_log inotifywait --recursive
 '
 
 if fanotify_supported; then
     test_expect_success 'event logged' '
+        rm -rf root &&
         run_and_check_log inotifywait --fanotify --recursive
     '
 fi
 
 # root requirement:
 # https://github.com/inotify-tools/inotify-tools/pull/183#issuecomment-1635518850
-if fanotify_supported --filesystem && [ $(id -u) -eq 0 ]; then
+if fanotify_supported --filesystem && is_root; then
     test_expect_success 'event logged' '
         test_when_finished "umount -l root" &&
         mount_filesystem ext2 10M root &&
+        run_and_check_log inotifywait --filesystem
+    '
+fi
+
+# Create files outside bind mount ($extdir) and inside bind mount ($subdir)
+# Expect to see only the log about the file created inside bind mount
+if fanotify_supported --filesystem && is_root; then
+    test_expect_success 'event logged' '
+        test_when_finished "umount -l $subdir root" &&
+        mount_filesystem ext2 10M root &&
+        mkdir -p $subdir $extdir &&
+        mount --bind $subdir $subdir &&
         run_and_check_log inotifywait --filesystem
     '
 fi

--- a/t/inotifywait-csv-watched-dir.t
+++ b/t/inotifywait-csv-watched-dir.t
@@ -44,7 +44,7 @@ test_expect_success 'event logged' '
 
 if fanotify_supported; then
     test_expect_success 'event logged' '
-	run_and_check_log fsnotifywait --fanotify
+	run_and_check_log inotifywait --fanotify
     '
 fi
 

--- a/t/inotifywait-daemon-logs-chown.t
+++ b/t/inotifywait-daemon-logs-chown.t
@@ -43,7 +43,7 @@ test_expect_success 'event logged' '
 
 if fanotify_supported; then
     test_expect_success 'event logged' '
-	run_and_check_log fsnotifywait --fanotify
+	run_and_check_log inotifywait --fanotify
     '
 fi
 

--- a/t/inotifywait-daemon-logs-to-relative-paths.t
+++ b/t/inotifywait-daemon-logs-to-relative-paths.t
@@ -43,7 +43,7 @@ test_expect_success 'event logged' '
 
 if fanotify_supported; then
     test_expect_success 'event logged' '
-	run_and_check_log fsnotifywait --fanotify
+	run_and_check_log inotifywait --fanotify
     '
 fi
 

--- a/t/inotifywait-format-option-cookie.t
+++ b/t/inotifywait-format-option-cookie.t
@@ -59,7 +59,7 @@ test_expect_success 'event logged' '
 
 if fanotify_supported; then
     test_expect_success 'event logged' '
-	run_and_check_log fsnotifywait --fanotify
+	run_and_check_log inotifywait --fanotify
     '
 fi
 

--- a/t/inotifywait-format-option-null.t
+++ b/t/inotifywait-format-option-null.t
@@ -52,7 +52,7 @@ test_expect_success 'the output is delimited by NUL' '
 
 if fanotify_supported; then
     test_expect_success 'the output is delimited by NUL' '
-	run_and_check_log fsnotifywait --fanotify
+	run_and_check_log inotifywait --fanotify
     '
 fi
 

--- a/t/inotifywait-format-watched-dir.t
+++ b/t/inotifywait-format-watched-dir.t
@@ -43,7 +43,7 @@ test_expect_success 'event logged' '
 
 if fanotify_supported; then
     test_expect_success 'event logged' '
-	run_and_check_log fsnotifywait --fanotify
+	run_and_check_log inotifywait --fanotify
     '
 fi
 

--- a/t/inotifywait-no-dereference-ignore-symlinked-file.t
+++ b/t/inotifywait-no-dereference-ignore-symlinked-file.t
@@ -20,7 +20,7 @@ test_expect_success 'Exit code 2 is returned' '
 
 if fanotify_supported; then
     test_expect_success 'Exit code 2 is returned' '
-        test_expect_code 2 run_ fsnotifywait --fanotify
+        test_expect_code 2 run_ inotifywait --fanotify
     '
 fi
 

--- a/t/inotifywait-no-dereference-respond-to-symlink-event.t
+++ b/t/inotifywait-no-dereference-respond-to-symlink-event.t
@@ -21,7 +21,7 @@ test_expect_success 'Exit code 0 is returned' '
 # FIXME: Why is the root required?
 if fanotify_supported && [ $(id -u) -eq 0 ]; then
     test_expect_success 'Exit code 0 is returned' '
-        run_ fsnotifywait --fanotify
+        run_ inotifywait --fanotify
     '
 fi
 

--- a/t/inotifywait-no-event-occured.t
+++ b/t/inotifywait-no-event-occured.t
@@ -17,7 +17,7 @@ test_expect_success 'Exit code 2 is returned' '
 
 if fanotify_supported; then
     test_expect_success 'Exit code 2 is returned' '
-        test_expect_code 2 run_ fsnotifywait --fanotify
+        test_expect_code 2 run_ inotifywait --fanotify
     '
 fi
 

--- a/t/sharness.sh
+++ b/t/sharness.sh
@@ -856,6 +856,8 @@ export SHARNESS_TRASH_DIRECTORY
 HOME="$SHARNESS_TRASH_DIRECTORY"
 export HOME
 
+# Set umask to ensure all directories are created with full permissions
+umask 000
 mkdir -p "$SHARNESS_TRASH_DIRECTORY" || exit 1
 # Use -P to resolve symlinks in our working directory so that the cwd
 # in subprocesses like git equals our $PWD (for pathname comparisons).


### PR DESCRIPTION
- Add new option --mount to setup fanotify mount watch
- Add tests for --mount and --filesystem (some skipped for non-root user)
- Fixes to support watching overlayfs with --fanotify (>= v6.6)
- Fixes to support watching btrfs sub-volume with --fanotify (>= v6.8)
- Fixes for filesystem watches set on a bind mount path
- Add tests for btrfs subvol and overlayfs (skipped if no kernel support)
